### PR TITLE
#4: getSubmitters can no longer return null

### DIFF
--- a/src/main/java/org/folg/gedcom/model/Gedcom.java
+++ b/src/main/java/org/folg/gedcom/model/Gedcom.java
@@ -198,7 +198,7 @@ public class Gedcom extends ExtensionContainer {
    public Submitter getSubmitter(String id) { return submitterIndex.get(id); }
 
    public List<Submitter> getSubmitters() {
-      return subms;
+      return subms != null ? subms : Collections.<Submitter>emptyList();
    }
 
    public void setSubmitters(List<Submitter> submitters) {


### PR DESCRIPTION
`Gedcom.getSubmitters()` now returns `Collections.<Submitter>emptyList()` instead of null.