### PR TITLE
Accept iteration on getSubmitters

### DIFF
--- a/src/main/java/org/folg/gedcom/model/Gedcom.java
+++ b/src/main/java/org/folg/gedcom/model/Gedcom.java
@@ -271,7 +271,7 @@ public class Gedcom extends ExtensionContainer {
          if (head != null) {
             head.accept(visitor);
          }
-         for (Submitter submitter : subms) {
+         for (Submitter submitter : getSubmitters()) {
             submitter.accept(visitor);
          }
          if (subn != null) {


### PR DESCRIPTION
The visitor pattern succeeds the [iteration on Submitters](https://github.com/FamilySearch/Gedcom/blob/bf091ee265b411662e0c380810d4d5ada25033b4/src/main/java/org/folg/gedcom/model/Gedcom.java#L274) only if a `subms` key exists in Gedcom object, otherwise it returns NullPointerException.
To avoid this, `Gedcom.accept(Visitor)` should iterate not directly on `subms`, that can be null, but on `getSubmitters()`, that returns an `emptyList` if `subms` is null. Moreover thus conforming to other iterators.
