### PR TITLE
Change date can have notes

### DIFF
--- a/src/main/java/org/folg/gedcom/model/Change.java
+++ b/src/main/java/org/folg/gedcom/model/Change.java
@@ -20,7 +20,7 @@ package org.folg.gedcom.model;
  * User: Dallan
  * Date: 12/25/11
  */
-public class Change extends ExtensionContainer {
+public class Change extends NoteContainer {
    private DateTime date = null;
 
    public DateTime getDateTime() {


### PR DESCRIPTION
According to the GEDCOM 5.5 and 5.5.1 specifications, the `CHANGE_DATE` structure can include some `NOTE_STRUCTURE`. For example:
```
1 CHAN
2 DATE 20 OCT 2018
3 TIME 22:08:57
2 NOTE @N1@
2 NOTE In-line note to the change date
```
So the `org.folg.gedcom.model.Change` should extend `NoteContainer` instead of `ExtensionContainer`.