### PR TITLE
#7: Cause is a String

### DIFF
--- a/src/main/java/org/folg/gedcom/model/EventFact.java
+++ b/src/main/java/org/folg/gedcom/model/EventFact.java
@@ -24,7 +24,6 @@ import java.util.*;
  * 
  * omit: Phone, Age, Agency, Cause (except for death events)
  * add: Rin, Uid
- * move: move caus tag for death events to its own event so it can have source citations; set EventFact.causeTag=tag of other event
  */
 public class EventFact extends SourceCitationContainer {
    public static final Set<String> PERSONAL_EVENT_FACT_TAGS = new HashSet<String>(Arrays.asList(
@@ -196,7 +195,7 @@ public class EventFact extends SourceCitationContainer {
    private String phon = null;
    private String fax = null;
    private String rin = null;
-   private EventFact caus = null;
+   private String caus = null;
    private String _uid = null;
    private String uidTag = null;
    private String _email = null;
@@ -283,11 +282,11 @@ public class EventFact extends SourceCitationContainer {
       this.fax = fax;
    }
 
-   public EventFact getCause() {
+   public String getCause() {
       return caus;
    }
 
-   public void setCause(EventFact caus) {
+   public void setCause(String caus) {
       this.caus = caus;
    }
 
@@ -351,9 +350,6 @@ public class EventFact extends SourceCitationContainer {
    public void visitContainedObjects(Visitor visitor) {
       if (addr != null) {
          addr.accept(visitor);
-      }
-      if (caus != null) {
-         caus.accept(visitor);
       }
       super.visitContainedObjects(visitor);
    }

--- a/src/main/java/org/folg/gedcom/parser/ModelParser.java
+++ b/src/main/java/org/folg/gedcom/parser/ModelParser.java
@@ -82,7 +82,7 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
    public static enum Tag {
       ABBR, ADDR, ADR1, ADR2, ADR3, _AKA, ALIA, ANCI, ASSO, AUTH,
       BLOB,
-      CALN, CHAN, CHAR, CHIL, CITY, CONC, CONT, COPR, CORP, CTRY,
+      CALN, CAUS, CHAN, CHAR, CHIL, CITY, CONC, CONT, COPR, CORP, CTRY,
       DATA, DATE, DESC, DESI, DEST,
       EMAIL, _EMAIL, _EML,
       FAM, FAMC, FAMS, FAX, _FILE, FILE, FONE, FORM, _FREL,
@@ -154,6 +154,9 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
             case CALN:
                obj = handleCaln(tos);
                break;
+            case CAUS:
+                obj = handleCaus(tos);
+                break;
             case CHAN:
                obj = handleChan(tos);
                break;
@@ -567,6 +570,13 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
       return null;
    }
 
+   private Object handleCaus(Object tos) {
+      if (tos instanceof EventFact && ((EventFact)tos).getCause() == null) {
+         return new FieldRef(tos, "Cause");
+      }
+      return null;
+   }
+
    private Object handleChan(Object tos) {
       if ((tos instanceof PersonFamilyCommonContainer && ((PersonFamilyCommonContainer)tos).getChange() == null) ||
           (tos instanceof Media && ((Media)tos).getChange() == null) ||
@@ -779,16 +789,10 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
 
    private Object handleEventFact(Object tos, String tagName, String tagNameUpper) {
       if ((tos instanceof Person && EventFact.PERSONAL_EVENT_FACT_TAGS.contains(tagNameUpper)) ||
-          (tos instanceof Family && EventFact.FAMILY_EVENT_FACT_TAGS.contains(tagNameUpper)) ||
-          (tos instanceof EventFact && "CAUS".equals(tagNameUpper) && ((EventFact)tos).getCause() == null)) {
+          (tos instanceof Family && EventFact.FAMILY_EVENT_FACT_TAGS.contains(tagNameUpper))) {
          EventFact eventFact = new EventFact();
          eventFact.setTag(tagName);
-         if (tos instanceof EventFact) {
-            ((EventFact)tos).setCause(eventFact);
-         }
-         else {
-            ((PersonFamilyCommonContainer)tos).addEventFact(eventFact);
-         }
+         ((PersonFamilyCommonContainer)tos).addEventFact(eventFact);
          return eventFact;
       }
       return null;

--- a/src/main/java/org/folg/gedcom/visitors/GedcomWriter.java
+++ b/src/main/java/org/folg/gedcom/visitors/GedcomWriter.java
@@ -225,6 +225,7 @@ public class GedcomWriter extends Visitor {
       writeString("TYPE", eventFact, eventFact.getType());
       writeString("DATE", eventFact, eventFact.getDate());
       writeString("PLAC", eventFact, eventFact.getPlace());
+      writeString("CAUS", eventFact, eventFact.getCause());
       writeString("RIN", eventFact, eventFact.getRin());
       writeString(eventFact.getUidTag(), eventFact, eventFact.getUid());
    }


### PR DESCRIPTION
Cause is now of type `String` instead of `EventFact`.
`ModelParser` has been successfully tested on import and export GEDCOM files containing `CAUS` tag.