### PR TITLE
Removed Gedcom.getSubmitter()

### DIFF
--- a/src/main/java/org/folg/gedcom/model/Gedcom.java
+++ b/src/main/java/org/folg/gedcom/model/Gedcom.java
@@ -181,20 +181,6 @@ public class Gedcom extends ExtensionContainer {
       }
    }
 
-   /**
-    * Use this function in place of Header.getSubmitter
-    * @return Submitter top-level record or from header
-    */
-   public Submitter getSubmitter() {
-      if (subms != null && !subms.isEmpty()) {
-         return subms.get(0);
-      }
-      else if (head != null) {
-         return submitterIndex.get(head.getSubmitterRef());
-      }
-      return null;
-   }
-
    public Submitter getSubmitter(String id) { return submitterIndex.get(id); }
 
    public List<Submitter> getSubmitters() {

--- a/src/main/java/org/folg/gedcom/model/Header.java
+++ b/src/main/java/org/folg/gedcom/model/Header.java
@@ -59,10 +59,6 @@ public class Header extends NoteContainer {
       this.date = date;
    }
 
-   /**
-    * Use Gedcom.getSubmitter in place of this function
-    * @return submitter reference
-    */
    public String getSubmitterRef() {
       return submRef;
    }
@@ -71,10 +67,6 @@ public class Header extends NoteContainer {
       this.submRef = submRef;
    }
 
-   /**
-    * Use Gedcom.getSubmitter in place of this function
-    * @return submitter
-    */
    public Submitter getSubmitter(Gedcom gedcom) {
       return gedcom.getSubmitter(submRef);
    }


### PR DESCRIPTION
Removed obsolete method `Gedcom.getSubmitter()` and 2 comments recommending to use it.