### PR TITLE
#16: Adding support for InputStream and Reader

### DIFF
--- a/src/main/java/org/folg/gedcom/parser/JsonParser.java
+++ b/src/main/java/org/folg/gedcom/parser/JsonParser.java
@@ -21,6 +21,8 @@ import com.google.gson.GsonBuilder;
 import org.folg.gedcom.model.Gedcom;
 import org.folg.gedcom.model.GedcomTag;
 
+import java.io.*;
+import java.nio.charset.Charset;
 import java.util.List;
 
 /**
@@ -28,39 +30,120 @@ import java.util.List;
  * Date: 1/2/12
  */
 public class JsonParser {
-   private Gson gson;
+    private Gson gson;
 
-   public JsonParser() {
-      gson = new GsonBuilder()
-                 .setPrettyPrinting()
-                 .registerTypeAdapter(Gedcom.class, new GedcomTypeAdapter())
-                 .create();
-   }
+    public JsonParser() {
+        gson = new GsonBuilder()
+                .setPrettyPrinting()
+                .registerTypeAdapter(Gedcom.class, new GedcomTypeAdapter())
+                .create();
+    }
 
-   /**
-    * Convert json-encoded string to Gedcom object
-    * @param json json-encoded string
-    * @return Gedcom object
-    */
-   public Gedcom fromJson(String json) {
-      return gson.fromJson(json, Gedcom.class);
-   }
+    /**
+     * Convert json-encoded string to Gedcom object
+     *
+     * @param json json-encoded string
+     * @return Gedcom object
+     */
+    public Gedcom fromJson(String json) {
+        return gson.fromJson(json, Gedcom.class);
+    }
 
-   /**
-    * Convert Gedcom object to json
-    * @param gedcom Gedcom
-    * @return json-encoded string
-    */
-   public String toJson(Gedcom gedcom) {
-      return gson.toJson(gedcom);
-   }
+    /**
+     * Read Gedcom object from json character stream
+     *
+     * @param reader json source reader
+     * @return Gedcom object
+     */
+    public Gedcom fromJson(Reader reader) {
+        return gson.fromJson(reader, Gedcom.class);
+    }
 
-   /**
-    * Convert output of TreeParser to json
-    * @param gedcomTags output of TreeParser
-    * @return json-encoded string
-    */
-   public String toJson(List<GedcomTag> gedcomTags) {
-      return gson.toJson(gedcomTags);
-   }
+    /**
+     * Read Gedcom object from json byte stream
+     *
+     * @param is json source stream
+     * @return Gedcom object
+     */
+    public Gedcom fromJson(InputStream is) {
+        InputStreamReader reader = new InputStreamReader(is, Charset.forName("UTF-8"));
+        return gson.fromJson(reader, Gedcom.class);
+    }
+
+    /**
+     * Convert Gedcom object to json
+     *
+     * @param gedcom Gedcom
+     * @return json-encoded string
+     */
+    public String toJson(Gedcom gedcom) {
+        return gson.toJson(gedcom);
+    }
+
+    /**
+     * Convert output of TreeParser to json
+     *
+     * @param gedcomTags output of TreeParser
+     * @return json-encoded string
+     */
+    public String toJson(List<GedcomTag> gedcomTags) {
+        return gson.toJson(gedcomTags);
+    }
+
+    /**
+     * Write Gedcom object to json character stream
+     *
+     * @param gedcom Gedcom object
+     * @param writer json output writer
+     */
+    public void write(Gedcom gedcom, Writer writer) {
+        gson.toJson(gedcom, writer);
+        close(writer);
+    }
+
+    /**
+     * Write Gedcom object to json byte stream
+     *
+     * @param gedcom Gedcom object
+     * @param os     json output stream
+     */
+    public void write(Gedcom gedcom, OutputStream os) {
+        OutputStreamWriter writer = new OutputStreamWriter(os, Charset.forName("UTF-8"));
+        gson.toJson(gedcom, writer);
+        close(writer);
+    }
+
+    /**
+     * Write Gedcom Tags from TreeParser to json character stream
+     *
+     * @param gedcomTags Gedcom tags
+     * @param writer     json output writer
+     */
+    public void write(List<GedcomTag> gedcomTags, Writer writer) {
+        gson.toJson(gedcomTags, writer);
+        close(writer);
+    }
+
+    /**
+     * Write Gedcom Tags from TreeParser to json byte stream
+     *
+     * @param gedcomTags Gedcom tags
+     * @param os         json output stream
+     */
+    public void write(List<GedcomTag> gedcomTags, OutputStream os) {
+        OutputStreamWriter writer = new OutputStreamWriter(os, Charset.forName("UTF-8"));
+        gson.toJson(gedcomTags, writer);
+        close(writer);
+    }
+
+    private void close(Writer writer) {
+        try {
+            if (writer != null) {
+                writer.close();
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Closing writer failed", e);
+        }
+    }
+
 }

--- a/src/main/java/org/folg/gedcom/parser/ModelParser.java
+++ b/src/main/java/org/folg/gedcom/parser/ModelParser.java
@@ -22,6 +22,8 @@ import org.xml.sax.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1562,10 +1564,28 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
    }
 
    public Gedcom parseGedcom(File gedcomFile) throws SAXParseException, IOException {
-      GedcomParser parser = new GedcomParser();
-      parser.setContentHandler(this);
-      parser.setErrorHandler(this);
+      GedcomParser parser = gedcomParser();
       parser.parse(gedcomFile.toURI().toString());
       return gedcom;
    }
+
+   public Gedcom parseGedcom(InputStream is) throws SAXParseException, IOException {
+      GedcomParser parser = gedcomParser();
+      parser.parse(is);
+      return gedcom;
+   }
+
+   public Gedcom parseGedcom(Reader reader) throws SAXParseException, IOException {
+      GedcomParser parser = gedcomParser();
+      parser.parse(reader);
+      return gedcom;
+   }
+
+   private GedcomParser gedcomParser() {
+      GedcomParser parser = new GedcomParser();
+      parser.setContentHandler(this);
+      parser.setErrorHandler(this);
+      return parser;
+   }
+
 }

--- a/src/main/java/org/folg/gedcom/parser/TreeParser.java
+++ b/src/main/java/org/folg/gedcom/parser/TreeParser.java
@@ -22,6 +22,8 @@ import org.xml.sax.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.util.List;
 import java.util.Stack;
 import org.slf4j.Logger;
@@ -140,11 +142,28 @@ public class TreeParser implements ContentHandler, org.xml.sax.ErrorHandler {
    }
 
    public List<GedcomTag> parseGedcom(File gedcomFile) throws SAXParseException, IOException {
+      GedcomParser parser = gedcomParser();
+      parser.parse(gedcomFile.toURI().toString());
+      return tree.getChildren();
+   }
+
+   public List<GedcomTag> parseGedcom(InputStream is) throws SAXParseException, IOException {
+      GedcomParser parser = gedcomParser();
+      parser.parse(is);
+      return tree.getChildren();
+   }
+
+   public List<GedcomTag> parseGedcom(Reader reader) throws SAXParseException, IOException {
+      GedcomParser parser = gedcomParser();
+      parser.parse(reader);
+      return tree.getChildren();
+   }
+
+   private GedcomParser gedcomParser() {
       GedcomParser parser = new GedcomParser();
       parser.setContentHandler(this);
       parser.setErrorHandler(this);
-      parser.parse(gedcomFile.toURI().toString());
-      return tree.getChildren();
+      return parser;
    }
 
 }

--- a/src/main/java/org/gedml/GedcomParser.java
+++ b/src/main/java/org/gedml/GedcomParser.java
@@ -1,11 +1,14 @@
 package org.gedml;
 
-import java.util.*;
+import org.xml.sax.*;
+import org.xml.sax.helpers.AttributesImpl;
+
 import java.io.*;
 import java.net.URL;
-
-import org.xml.sax.*;
-import org.xml.sax.helpers.*;
+import java.util.Arrays;
+import java.util.EmptyStackException;
+import java.util.List;
+import java.util.Stack;
 
 /**
  * This class is designed to look like a SAX2-compliant XML parser; however,
@@ -18,425 +21,439 @@ import org.xml.sax.helpers.*;
  * Also revised in 2007 by Nathan Powell and revised in 2011 by Dallan Quass
  */
 public class GedcomParser implements XMLReader, Locator {
-   private static final List<String> ACCEPTED_TRUE_SAX_FEATURES = Arrays.asList(
-           "http://xml.org/sax/features/namespace-prefixes",
-           // OK to support, since non are produced from gedcom
-           "http://xml.org/sax/features/external-general-entities",
-           // OK to support, since non are produced from gedcom
-           "http://xml.org/sax/features/external-parameter-entities",
-           // OK to support, since non are produced from gedcom
-           "http://xml.org/sax/features/string-interning"
-   );
+    private static final List<String> ACCEPTED_TRUE_SAX_FEATURES = Arrays.asList(
+            "http://xml.org/sax/features/namespace-prefixes",
+            // OK to support, since non are produced from gedcom
+            "http://xml.org/sax/features/external-general-entities",
+            // OK to support, since non are produced from gedcom
+            "http://xml.org/sax/features/external-parameter-entities",
+            // OK to support, since non are produced from gedcom
+            "http://xml.org/sax/features/string-interning"
+    );
 
-   private ContentHandler contentHandler;
-   private ErrorHandler errorHandler;
-   private AttributesImpl emptyAttList = new AttributesImpl();
-   private AttributesImpl attList = new AttributesImpl();
-   private EntityResolver entityResolver = null;
-   private String systemId;
-   private int lineNr;
+    private ContentHandler contentHandler;
+    private ErrorHandler errorHandler;
+    private AttributesImpl emptyAttList = new AttributesImpl();
+    private AttributesImpl attList = new AttributesImpl();
+    private EntityResolver entityResolver = null;
+    private String systemId;
+    private int lineNr;
 
-   /**
-    * Set the ContentHandler
-    *
-    * @param handler User-supplied content handler
-    */
-   public void setContentHandler(ContentHandler handler) {
-      contentHandler = handler;
-   }
+    /**
+     * Set the ContentHandler
+     *
+     * @param handler User-supplied content handler
+     */
+    public void setContentHandler(ContentHandler handler) {
+        contentHandler = handler;
+    }
 
-   /**
-    * Get the ContentHandler
-    */
-   public ContentHandler getContentHandler() {
-      return contentHandler;
-   }
+    /**
+     * Get the ContentHandler
+     */
+    public ContentHandler getContentHandler() {
+        return contentHandler;
+    }
 
-   /**
-    * Set the entityResolver.
-    * This call has no effect, because entities are not used in GEDCOM files.
-    */
-   public void setEntityResolver(EntityResolver er) {
-      entityResolver = er;
-   }
+    /**
+     * Set the entityResolver.
+     * This call has no effect, because entities are not used in GEDCOM files.
+     */
+    public void setEntityResolver(EntityResolver er) {
+        entityResolver = er;
+    }
 
-   /**
-    * Get the entityResolver
-    */
-   public EntityResolver getEntityResolver() {
-      return entityResolver;
-   }
+    /**
+     * Get the entityResolver
+     */
+    public EntityResolver getEntityResolver() {
+        return entityResolver;
+    }
 
-   /**
-    * Set the DTDHandler
-    * This call has no effect, because DTDs are not used in GEDCOM files.
-    */
-   public void setDTDHandler(DTDHandler dh) {
-   }
+    /**
+     * Set the DTDHandler
+     * This call has no effect, because DTDs are not used in GEDCOM files.
+     */
+    public void setDTDHandler(DTDHandler dh) {
+    }
 
-   /**
-    * Get the DTDHandler
-    */
-   public DTDHandler getDTDHandler() {
-      return null;
-   }
+    /**
+     * Get the DTDHandler
+     */
+    public DTDHandler getDTDHandler() {
+        return null;
+    }
 
-   /**
-    * Set the error handler
-    *
-    * @param eh A user-supplied error handler
-    */
-   public void setErrorHandler(ErrorHandler eh) {
-      errorHandler = eh;
-   }
+    /**
+     * Set the error handler
+     *
+     * @param eh A user-supplied error handler
+     */
+    public void setErrorHandler(ErrorHandler eh) {
+        errorHandler = eh;
+    }
 
-   /**
-    * Get the error handler
-    */
-   public ErrorHandler getErrorHandler() {
-      return errorHandler;
-   }
+    /**
+     * Get the error handler
+     */
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
 
-   public static String readCorrectedCharsetName(InputStream is) throws IOException {
-      BufferedReader in = new BufferedReader(new InputStreamReader(is));
-      return readCorrectedCharsetName(in);
-   }
+    private static String readCorrectedCharsetName(InputStream is) throws IOException {
+        BufferedReader in = new BufferedReader(new InputStreamReader(is));
+        return readCorrectedCharsetName(in);
+    }
 
-   private static String readCorrectedCharsetName(BufferedReader in) throws IOException {
-      // We will only try to read the first 100 lines of
-      // the file attempting to get the char encoding.
-      String line;
-      String generatorName = null;
-      String encoding = null;
-      String version = null;
-      for (int i = 0; i < 100; i++) {
-         line = in.readLine();
-         if (line != null) {
-            String [] split = line.trim().split("\\s+", 3);
-            if (split.length == 3) {
-               if (generatorName == null &&
-                       split[0].equals("1") &&
-                       split[1].equals("SOUR")) {
-                  generatorName = split[2];
-               }
-               else if (split[0].equals("1") &&
-                       (split[1].equals("CHAR") || split[1].equals("CHARACTER"))) {
-                  // get encoding
-                  encoding = split[2].toUpperCase();
-                  // look for version
-                  line = in.readLine();
-                  if (line != null) {
-                     split = line.trim().split("\\s+", 3);
-                     if (split.length == 3 && split[0].equals("2") && split[1].equals("VERS")) {
-                        version = split[2];
-                     }
-                  }
-               }
+    private static String readCorrectedCharsetName(BufferedReader in) throws IOException {
+        // We will only try to read the first 100 lines of
+        // the file attempting to get the char encoding.
+        String line;
+        String generatorName = null;
+        String encoding = null;
+        String version = null;
+        for (int i = 0; i < 100; i++) {
+            line = in.readLine();
+            if (line != null) {
+                String[] split = line.trim().split("\\s+", 3);
+                if (split.length == 3) {
+                    if (generatorName == null &&
+                            split[0].equals("1") &&
+                            split[1].equals("SOUR")) {
+                        generatorName = split[2];
+                    } else if (split[0].equals("1") &&
+                            (split[1].equals("CHAR") || split[1].equals("CHARACTER"))) {
+                        // get encoding
+                        encoding = split[2].toUpperCase();
+                        // look for version
+                        line = in.readLine();
+                        if (line != null) {
+                            split = line.trim().split("\\s+", 3);
+                            if (split.length == 3 && split[0].equals("2") && split[1].equals("VERS")) {
+                                version = split[2];
+                            }
+                        }
+                    }
+                }
             }
-         }
-         if (generatorName != null && encoding != null) {
-            break; // got what we need
-         }
-      }
-      in.close();
+            if (generatorName != null && encoding != null) {
+                break; // got what we need
+            }
+        }
 
-      return getCorrectedCharsetName(generatorName, encoding, version);
-   }
+        return getCorrectedCharsetName(generatorName, encoding, version);
+    }
 
-   public static String getCorrectedCharsetName(String generatorName, String encoding, String version) {
-      // correct incorrectly-assigned encoding values
-      if ("GeneWeb".equals(generatorName) && "ASCII".equals(encoding)) {
-         // GeneWeb ASCII -> Cp1252 (ANSI)
-         encoding = "Cp1252";
-      }
-      else if ("Geni.com".equals(generatorName) && "UNICODE".equals(encoding)) {
-         // Geni.com UNICODE -> UTF-8
-         encoding = "UTF-8";
-      }
-      else if ("Geni.com".equals(generatorName) && "ANSEL".equals(encoding)) {
-         // Geni.com ANSEL -> UTF-8
-         encoding = "UTF-8";
-      }
-      else if ("GENJ".equals(generatorName) && "UNICODE".equals(encoding)) {
-         // GENJ UNICODE -> UTF-8
-         encoding = "UTF-8";
-      }
+    public static String getCorrectedCharsetName(String generatorName, String encoding, String version) {
+        // correct incorrectly-assigned encoding values
+        if ("GeneWeb".equals(generatorName) && "ASCII".equals(encoding)) {
+            // GeneWeb ASCII -> Cp1252 (ANSI)
+            encoding = "Cp1252";
+        } else if ("Geni.com".equals(generatorName) && "UNICODE".equals(encoding)) {
+            // Geni.com UNICODE -> UTF-8
+            encoding = "UTF-8";
+        } else if ("Geni.com".equals(generatorName) && "ANSEL".equals(encoding)) {
+            // Geni.com ANSEL -> UTF-8
+            encoding = "UTF-8";
+        } else if ("GENJ".equals(generatorName) && "UNICODE".equals(encoding)) {
+            // GENJ UNICODE -> UTF-8
+            encoding = "UTF-8";
+        }
 
-      // make encoding value java-friendly
-      else if ("ASCII".equals(encoding)) { // ASCII followed by VERS MacOS Roman is MACINTOSH
-         if ("MacOS Roman".equals(version)) {
+        // make encoding value java-friendly
+        else if ("ASCII".equals(encoding)) { // ASCII followed by VERS MacOS Roman is MACINTOSH
+            if ("MacOS Roman".equals(version)) {
+                encoding = "x-MacRoman";
+            }
+        } else if ("ATARIST_ASCII".equals(encoding)) {
+            encoding = "ASCII";
+        } else if ("MACROMAN".equals(encoding) || "MACINTOSH".equals(encoding)) {
             encoding = "x-MacRoman";
-         }
-      }
-      else if ("ATARIST_ASCII".equals(encoding)) {
-         encoding = "ASCII";
-      }
-      else if ("MACROMAN".equals(encoding) || "MACINTOSH".equals(encoding)) {
-         encoding = "x-MacRoman";
-      }
-      else if ("ANSI".equals(encoding) || "IBM WINDOWS".equals(encoding)) {
-         encoding = "Cp1252";
-      }
-      else if ("WINDOWS-874".equals(encoding)) {
-         encoding = "Cp874";
-      }
-      else if ("WINDOWS-1251".equals(encoding)) {
-         encoding = "Cp1251";
-      }
-      else if ("WINDOWS-1254".equals(encoding)) {
-         encoding = "Cp1254";
-      }
-      else if ("IBMPC".equals(encoding) || "IBM DOS".equals(encoding)) {
-         encoding = "Cp850";
-      }
-      else if ("UNICODE".equals(encoding)) {
-         encoding = "UTF-16";
-      }
-      else if ("UTF-16BE".equals(encoding)) {
-         encoding = "UnicodeBigUnmarked";
-      }
-      else if (encoding == null) {
-         encoding = ""; // not found
-      }
+        } else if ("ANSI".equals(encoding) || "IBM WINDOWS".equals(encoding)) {
+            encoding = "Cp1252";
+        } else if ("WINDOWS-874".equals(encoding)) {
+            encoding = "Cp874";
+        } else if ("WINDOWS-1251".equals(encoding)) {
+            encoding = "Cp1251";
+        } else if ("WINDOWS-1254".equals(encoding)) {
+            encoding = "Cp1254";
+        } else if ("IBMPC".equals(encoding) || "IBM DOS".equals(encoding)) {
+            encoding = "Cp850";
+        } else if ("UNICODE".equals(encoding)) {
+            encoding = "UTF-16";
+        } else if ("UTF-16BE".equals(encoding)) {
+            encoding = "UnicodeBigUnmarked";
+        } else if (encoding == null) {
+            encoding = ""; // not found
+        }
 
-      return encoding;
-   }
+        return encoding;
+    }
 
-   private BufferedReader getBufferedReader(String systemId) throws IOException, SAXException {
-      InputStream in = (new URL(systemId)).openStream();
-      String charEncoding = readCorrectedCharsetName(in);
-      in.close();
+    private BufferedReader getBufferedReader(InputStream in) throws IOException {
+        if (!in.markSupported()) {
+            in = new BufferedInputStream(in);
+        }
+        in.mark(Integer.MAX_VALUE);
 
-      if (charEncoding.length() == 0) {
-         // Let's try again with a UTF-16 reader.
-         BufferedReader br = new BufferedReader(new InputStreamReader((new URL(systemId)).openStream(), "UTF-16"));
-         charEncoding = readCorrectedCharsetName(br);
-         br.close();
-         if (charEncoding.equals("UTF-16")) {
-            // skip over junk at the beginning of the file
-            InputStreamReader reader = new InputStreamReader((new URL(systemId)).openStream(), "UTF-16");
-            int cnt = 0;
-            int c;
-            while ((c = reader.read()) != '0' && c != -1) {
-               cnt++;
+        String charEncoding = readCorrectedCharsetName(in);
+        in.reset();
+
+        if (charEncoding.length() == 0) {
+            // Let's try again with a UTF-16 reader.
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-16"));
+            charEncoding = readCorrectedCharsetName(br);
+            in.reset();
+
+            if (charEncoding.equals("UTF-16")) {
+                // skip over junk at the beginning of the file
+                InputStreamReader reader = new InputStreamReader(in, "UTF-16");
+                int cnt = 0;
+                int c;
+                while ((c = reader.read()) != '0' && c != -1) {
+                    cnt++;
+                }
+
+                in.reset();
+                reader = new InputStreamReader(in, "UTF-16");
+                for (int i = 0; i < cnt; i++) {
+                    reader.read();
+                }
+                return new BufferedReader(reader);
             }
-            reader.close();
-            reader = new InputStreamReader((new URL(systemId)).openStream(), "UTF-16");
-            for (int i = 0; i < cnt; i++) {
-               reader.read();
+        }
+
+        if (charEncoding.length() == 0) {
+            charEncoding = "ANSEL"; // default
+        }
+
+        // skip over junk at the beginning of the file
+        in.reset();
+        int cnt = 0;
+        int c;
+        while ((c = in.read()) != '0' && c != -1) {
+            cnt++;
+        }
+
+        in.reset();
+        for (int i = 0; i < cnt; i++) {
+            in.read();
+        }
+
+        InputStreamReader reader;
+        if (charEncoding.equals("ANSEL")) {
+            reader = new AnselInputStreamReader(in);
+        } else {
+            reader = new InputStreamReader(in, charEncoding);
+        }
+
+        return new BufferedReader(reader);
+    }
+
+    /**
+     * Parse input from the supplied InputSource.  Per {InputSource}, any character stream provided will be used
+     * first, then any byte stream, and lastly the system Id.
+     */
+    public void parse(InputSource source) throws IOException, SAXParseException {
+        this.systemId = source.getSystemId();
+
+        if (source.getCharacterStream() != null) {
+            parse(source.getCharacterStream());
+        } else if (source.getByteStream() != null) {
+            parse(source.getByteStream());
+        } else {
+            parse(this.systemId);
+        }
+    }
+
+    /**
+     * Parse input from the supplied systemId
+     */
+    public void parse(String systemId) throws IOException, SAXParseException {
+        this.systemId = systemId;
+        InputStream is = (new URL(systemId)).openStream();
+        parse(is);
+    }
+
+    /**
+     * Parse input from the supplied InputStream
+     */
+    public void parse(InputStream is) throws IOException, SAXParseException {
+        BufferedReader reader = getBufferedReader(is);
+        parse(reader);
+    }
+
+    /**
+     * Parse input from the supplied Reader.  WARNING: It is assumed that the given Reader has been initialized
+     * with the appropriate character encoding for its underlying input stream.
+     */
+    public void parse(Reader reader) throws IOException, SAXParseException {
+        BufferedReader br = new BufferedReader(reader);
+        parse(br);
+    }
+
+    private void parse(BufferedReader reader) throws IOException, SAXParseException {
+        String line;
+        int thisLevel;
+        int prevLevel = -1;
+        String iden, tag, xref, valu;
+        lineNr = 0;
+        Stack<String> stack = new Stack<String>();
+        stack.push("GED");
+        StringBuilder buf = new StringBuilder();
+
+        try {
+            contentHandler.setDocumentLocator(this);
+            contentHandler.startDocument();
+            contentHandler.startElement("", "GED", "GED", emptyAttList);
+            boolean goodLine = false; // Indicates whether we have found a good line so far in the file.
+            GedcomLineParser lineParser = new GedcomLineParser();
+            while ((line = reader.readLine()) != null) {
+                lineNr++;
+
+                // remove control chars
+                buf.setLength(0);
+                for (int j = 0; j < line.length(); j++) {
+                    char c = line.charAt(j);
+                    if (c >= 32 || c == 9) {
+                        buf.append(c);
+                    }
+                }
+                line = buf.toString();
+
+                if (line.length() > 0) {
+                    // parse the GEDCOM line into five fields: level, iden, tag, xref, value
+                    if (!lineParser.parse(line)) {
+                        if (goodLine) {
+                            errorHandler.error(new SAXParseException("Line does not appear to be standard @ " +
+                                    this.getLineNumber() + " appending content to the last tag started." + line, this));
+                            contentHandler.characters(line.toCharArray(), 0, line.length());
+                        } // if we haven't found a good line yet, just skip it
+                        if (lineNr > 20 && !goodLine) {
+                            break;
+                        }
+                    } else {
+                        thisLevel = Integer.parseInt(lineParser.getLevel());
+                        tag = lineParser.getTag();
+
+                        // if level is > prevlevel+1, ignore it until it comes back down
+                        if (thisLevel > prevLevel + 1) {
+                            errorHandler.error(new SAXParseException("Level > prevLevel+1 @ " + this.getLineNumber(), this));
+                        } else if (thisLevel < 0) {
+                            errorHandler.error(new SAXParseException("Level < 0 @ " + this.getLineNumber(), this));
+                        } else if (tag == null || tag.length() == 0) {
+                            errorHandler.error(new SAXParseException("Tag not found @ " + this.getLineNumber(), this));
+                        } else {
+                            iden = lineParser.getID();
+                            xref = lineParser.getXRef();
+                            valu = lineParser.getValue();
+
+                            // insert any necessary closing tags
+                            while (thisLevel <= prevLevel) {
+                                String endtag = stack.pop();
+                                contentHandler.endElement("", endtag, endtag);
+                                prevLevel--;
+                            }
+                            attList.clear();
+                            if (iden != null && iden.length() > 0) attList.addAttribute("", "ID", "ID", "ID", iden);
+                            if (xref != null && xref.length() > 0)
+                                attList.addAttribute("", "REF", "REF", "IDREF", xref);
+                            contentHandler.startElement("", tag, tag, attList);
+                            goodLine = true;
+                            stack.push(tag);
+                            prevLevel = thisLevel;
+                            if (valu != null && valu.length() > 0) {
+                                contentHandler.characters(valu.toCharArray(), 0, valu.length());
+                            }
+                        }
+                    }
+                }
             }
-            return new BufferedReader(reader);
-         }
-      }
 
-      if (charEncoding.length() == 0) {
-         charEncoding = "ANSEL"; // default
-      }
-
-      // skip over junk at the beginning of the file
-      in = (new URL(systemId)).openStream();
-      int cnt = 0;
-      int c;
-      while ((c = in.read()) != '0' && c != -1) {
-         cnt++;
-      }
-      in.close();
-      in = (new URL(systemId)).openStream();
-      for (int i = 0; i < cnt; i++) {
-         in.read();
-      }
-
-      InputStreamReader reader;
-      if (charEncoding.equals("ANSEL")) {
-         reader = new AnselInputStreamReader(in);
-      }
-      else {
-         reader = new InputStreamReader(in, charEncoding);
-      }
-
-      return new BufferedReader(reader);
-   }
-
-   /**
-    * Parse input from the supplied InputSource
-    */
-   public void parse(InputSource source) throws IOException, SAXParseException {
-      parse(source.getSystemId());
-   }
-
-   /**
-    * Parse input from the supplied systemId
-    */
-   public void parse(String systemId) throws IOException, SAXParseException {
-      this.systemId = systemId;
-      String line;
-      int thisLevel;
-      int prevLevel = -1;
-      String iden, tag, xref, valu;
-      lineNr = 0;
-      Stack<String> stack = new Stack<String>();
-      stack.push("GED");
-      BufferedReader reader = null;
-      StringBuilder buf = new StringBuilder();
-
-      try {
-         reader = getBufferedReader(systemId);
-         contentHandler.setDocumentLocator(this);
-         contentHandler.startDocument();
-         contentHandler.startElement("", "GED", "GED", emptyAttList);
-         boolean goodLine = false; // Indicates whether we have found a good line so far in the file.
-         GedcomLineParser lineParser = new GedcomLineParser();
-         while ((line = reader.readLine()) != null) {
-            lineNr++;
-
-            // remove control chars
-            buf.setLength(0);
-            for (int j=0; j < line.length(); j++) {
-               char c = line.charAt(j);
-               if (c >= 32 || c == 9) {
-                  buf.append(c);
-               }
+            if (!goodLine) {
+                throw new SAXParseException("no good lines found in the first 20 lines ", this);
             }
-            line = buf.toString();
-
-            if (line.length() > 0) {
-               // parse the GEDCOM line into five fields: level, iden, tag, xref, value
-               if (!lineParser.parse(line))
-               {
-                  if (goodLine) {
-                     errorHandler.error(new SAXParseException("Line does not appear to be standard @ " +
-                             this.getLineNumber() + " appending content to the last tag started." + line, this));
-                     contentHandler.characters(line.toCharArray(), 0, line.length());
-                  } // if we haven't found a good line yet, just skip it
-                  if (lineNr > 20 && !goodLine) {
-                     break;
-                  }
-               }
-               else {
-                  thisLevel = Integer.parseInt(lineParser.getLevel());
-                  tag = lineParser.getTag();
-
-                  // if level is > prevlevel+1, ignore it until it comes back down
-                  if (thisLevel > prevLevel+1) {
-                     errorHandler.error(new SAXParseException("Level > prevLevel+1 @ " + this.getLineNumber(), this));
-                  }
-                  else if (thisLevel < 0) {
-                     errorHandler.error(new SAXParseException("Level < 0 @ " + this.getLineNumber(), this));
-                  }
-                  else if (tag == null || tag.length() == 0) {
-                     errorHandler.error(new SAXParseException("Tag not found @ " + this.getLineNumber(), this));
-                  }
-                  else {
-                     iden = lineParser.getID();
-                     xref = lineParser.getXRef();
-                     valu = lineParser.getValue();
-
-                     // insert any necessary closing tags
-                     while (thisLevel <= prevLevel) {
-                        String endtag = stack.pop();
-                        contentHandler.endElement("", endtag, endtag);
-                        prevLevel--;
-                     }
-                     attList.clear();
-                     if (iden != null && iden.length() > 0) attList.addAttribute("", "ID", "ID", "ID", iden);
-                     if (xref != null && xref.length() > 0) attList.addAttribute("", "REF", "REF", "IDREF", xref);
-                     contentHandler.startElement("", tag, tag, attList);
-                     goodLine = true;
-                     stack.push(tag);
-                     prevLevel = thisLevel;
-                     if (valu != null && valu.length() > 0) {
-                        contentHandler.characters(valu.toCharArray(), 0, valu.length());
-                     }
-                  }
-               }
+            contentHandler.endElement("", "GED", "GED");
+            contentHandler.endDocument();
+        } catch (SAXException e) {
+            SAXParseException err = new SAXParseException("SAXException: " + e.getMessage(), this);
+            try {
+                errorHandler.fatalError(err);
+            } catch (SAXException e1) {
+                // ignore
             }
-         }
+            throw err;
+        } catch (EmptyStackException e) {
+            SAXParseException err = new SAXParseException("EmptyStack: " + e.getMessage(), this);
+            try {
+                errorHandler.fatalError(err);
+            } catch (SAXException e1) {
+                // ignore
+            }
+            throw err;
+        } finally {
+            if (reader != null) {
+                reader.close();
+            }
+        }
+    }
 
-         if (!goodLine) {
-            throw new SAXParseException("no good lines found in the first 20 lines ", this);
-         }
-         contentHandler.endElement("", "GED", "GED");
-         contentHandler.endDocument();
-      } catch (SAXException e) {
-         SAXParseException err = new SAXParseException("SAXException: "+e.getMessage(), this);
-         try {
-            errorHandler.fatalError(err);
-         } catch (SAXException e1) {
-            // ignore
-         }
-         throw err;
-      } catch (EmptyStackException e) {
-         SAXParseException err = new SAXParseException("EmptyStack: "+e.getMessage(), this);
-         try {
-            errorHandler.fatalError(err);
-         } catch (SAXException e1) {
-            // ignore
-         }
-         throw err;
-      }
-      finally {
-         if (reader != null) {
-            reader.close();
-         }
-      }
-   }
+    /**
+     * Set a feature
+     */
+    public void setFeature(String s, boolean b) throws SAXNotRecognizedException {
+        if (!b || !ACCEPTED_TRUE_SAX_FEATURES.contains(s))
+            throw new SAXNotRecognizedException("Gedcom Parser does not recognize the feature '" + s + "'");
+    }
 
-   /**
-    * Set a feature
-    */
-   public void setFeature(String s, boolean b) throws SAXNotRecognizedException {
-      if (!b || !ACCEPTED_TRUE_SAX_FEATURES.contains(s))
-         throw new SAXNotRecognizedException("Gedcom Parser does not recognize the feature '" + s + "'");
-   }
+    /**
+     * Get a feature
+     */
+    public boolean getFeature(String s) throws SAXNotRecognizedException {
+        if (s.equals("http://xml.org/sax/features/namespaces")) return true;
+        if (s.equals("http://xml.org/sax/features/namespace-prefixes")) return false;
+        throw new SAXNotRecognizedException("Gedcom Parser does not recognize any features");
+    }
 
-   /**
-    * Get a feature
-    */
-   public boolean getFeature(String s) throws SAXNotRecognizedException {
-      if (s.equals("http://xml.org/sax/features/namespaces")) return true;
-      if (s.equals("http://xml.org/sax/features/namespace-prefixes")) return false;
-      throw new SAXNotRecognizedException("Gedcom Parser does not recognize any features");
-   }
+    /**
+     * Set a property
+     */
+    public void setProperty(String s, Object b) throws SAXNotRecognizedException {
+        throw new SAXNotRecognizedException("Gedcom Parser does not recognize any properties");
+    }
 
-   /**
-    * Set a property
-    */
-   public void setProperty(String s, Object b) throws SAXNotRecognizedException {
-      throw new SAXNotRecognizedException("Gedcom Parser does not recognize any properties");
-   }
+    /**
+     * Get a property
+     */
+    public Object getProperty(String s) throws SAXNotRecognizedException {
+        throw new SAXNotRecognizedException("Gedcom Parser does not recognize any properties");
+    }
 
-   /**
-    * Get a property
-    */
-   public Object getProperty(String s) throws SAXNotRecognizedException {
-      throw new SAXNotRecognizedException("Gedcom Parser does not recognize any properties");
-   }
+    /**
+     * Get the publicId: always null
+     */
+    public String getPublicId() {
+        return null;
+    }
 
-   /**
-    * Get the publicId: always null
-    */
-   public String getPublicId() {
-      return null;
-   }
+    /**
+     * Get the system ID
+     */
+    public String getSystemId() {
+        return systemId;
+    }
 
-   /**
-    * Get the system ID
-    */
-   public String getSystemId() {
-      return systemId;
-   }
+    /**
+     * Get the line number
+     */
+    public int getLineNumber() {
+        return lineNr;
+    }
 
-   /**
-    * Get the line number
-    */
-   public int getLineNumber() {
-      return lineNr;
-   }
-
-   /**
-    * Get the column number: always -1
-    */
-   public int getColumnNumber() {
-      return -1;
-   }
+    /**
+     * Get the column number: always -1
+     */
+    public int getColumnNumber() {
+        return -1;
+    }
 }

--- a/src/test/java/org/folg/gedcom/parser/JsonParserTest.java
+++ b/src/test/java/org/folg/gedcom/parser/JsonParserTest.java
@@ -1,0 +1,246 @@
+package org.folg.gedcom.parser;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.folg.gedcom.model.*;
+import org.testng.annotations.Test;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.Collections;
+
+import static org.testng.Assert.*;
+
+public class JsonParserTest {
+
+    @Test
+    public void testToJson_gedcom() {
+        String expectedLanguage = "English";
+        String expectedCopyright = "2019";
+        String expectedName = "Bobby /ROBERTSON/";
+        String expectedId = "I1";
+
+        Header header = new Header();
+        header.setLanguage(expectedLanguage);
+        header.setCopyright(expectedCopyright);
+
+        Name name = new Name();
+        name.setValue(expectedName);
+        Person individual = new Person();
+        individual.setId(expectedId);
+        individual.setNames(Collections.singletonList(name));
+
+        Gedcom gedcom = new Gedcom();
+        gedcom.setHeader(header);
+        gedcom.addPerson(individual);
+
+        JsonParser jsonParser = new JsonParser();
+        String json = jsonParser.toJson(gedcom);
+        assertNotNull(json);
+
+        com.google.gson.JsonParser gsonParser = new com.google.gson.JsonParser();
+        JsonElement jsonElement = gsonParser.parse(json);
+        assertNotNull(jsonElement);
+        assertTrue(jsonElement.isJsonObject());
+
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+        JsonElement head = jsonObject.get("head");
+        assertNotNull(head);
+        assertTrue(head.isJsonObject());
+
+        JsonObject headObj = head.getAsJsonObject();
+
+        JsonElement copr = headObj.get("copr");
+        assertNotNull(copr);
+        assertTrue(copr.isJsonPrimitive());
+        assertEquals(expectedCopyright, copr.getAsString());
+
+        JsonElement lang = headObj.get("lang");
+        assertNotNull(lang);
+        assertTrue(lang.isJsonPrimitive());
+        assertEquals(expectedLanguage, lang.getAsString());
+
+        JsonElement people = jsonObject.get("people");
+        assertNotNull(people);
+        assertTrue(people.isJsonArray());
+
+        JsonArray peopleArray = people.getAsJsonArray();
+        assertEquals(1, peopleArray.size());
+
+        JsonElement indi = peopleArray.get(0);
+        assertNotNull(indi);
+        assertTrue(indi.isJsonObject());
+
+        JsonObject indiObj = indi.getAsJsonObject();
+
+        JsonElement id = indiObj.get("id");
+        assertNotNull(id);
+        assertTrue(id.isJsonPrimitive());
+        assertEquals(expectedId, id.getAsString());
+
+        JsonElement names = indiObj.get("names");
+        assertNotNull(names);
+        assertTrue(names.isJsonArray());
+
+        JsonArray namesArray = names.getAsJsonArray();
+        assertEquals(1, namesArray.size());
+
+        JsonElement nameElt = namesArray.get(0);
+        assertNotNull(nameElt);
+        assertTrue(nameElt.isJsonObject());
+
+        JsonObject nameObj = nameElt.getAsJsonObject();
+
+        JsonElement nameValue = nameObj.get("value");
+        assertNotNull(nameValue);
+        assertTrue(nameValue.isJsonPrimitive());
+        assertEquals(expectedName, nameValue.getAsString());
+    }
+
+    @Test
+    public void testToJson_gedcomTags() {
+        GedcomTag tag = new GedcomTag("", "head", "");
+        JsonParser jsonParser = new JsonParser();
+        String json = jsonParser.toJson(Collections.singletonList(tag));
+
+        assertGedcomTagsJson(json);
+    }
+
+    @Test
+    public void testFromJson() {
+        Header header = new Header();
+        header.setLanguage("English");
+        header.setCopyright("2019");
+
+        Gedcom gedcom = new Gedcom();
+        gedcom.setHeader(header);
+
+        JsonParser jsonParser = new JsonParser();
+        String json = jsonParser.toJson(gedcom);
+
+        assertGedcomJson(gedcom, json);
+    }
+
+    @Test
+    public void testFromJson_withReader() {
+        Header header = new Header();
+        header.setLanguage("English");
+        header.setCopyright("2019");
+
+        Gedcom gedcom = new Gedcom();
+        gedcom.setHeader(header);
+
+        JsonParser jsonParser = new JsonParser();
+        String json = jsonParser.toJson(gedcom);
+
+        StringReader reader = new StringReader(json);
+        Gedcom actualGedcom = jsonParser.fromJson(reader);
+        assertNotNull(actualGedcom);
+        assertEquals(gedcom.getHeader().getLanguage(), actualGedcom.getHeader().getLanguage());
+        assertEquals(gedcom.getHeader().getCopyright(), actualGedcom.getHeader().getCopyright());
+    }
+
+    @Test
+    public void testFromJson_withInputStream() {
+        Header header = new Header();
+        header.setLanguage("English");
+        header.setCopyright("2019");
+
+        Gedcom gedcom = new Gedcom();
+        gedcom.setHeader(header);
+
+        JsonParser jsonParser = new JsonParser();
+        String json = jsonParser.toJson(gedcom);
+
+        ByteArrayInputStream is = new ByteArrayInputStream(json.getBytes(Charset.forName("UTF-8")));
+        Gedcom actualGedcom = jsonParser.fromJson(is);
+        assertNotNull(actualGedcom);
+        assertEquals(gedcom.getHeader().getLanguage(), actualGedcom.getHeader().getLanguage());
+        assertEquals(gedcom.getHeader().getCopyright(), actualGedcom.getHeader().getCopyright());
+    }
+
+    @Test
+    public void testWrite_withGedcomAndWriter() {
+        Header header = new Header();
+        header.setLanguage("English");
+        header.setCopyright("2019");
+
+        Gedcom gedcom = new Gedcom();
+        gedcom.setHeader(header);
+
+        Writer writer = new StringWriter();
+        JsonParser jsonParser = new JsonParser();
+        jsonParser.write(gedcom, writer);
+
+        assertGedcomJson(gedcom, writer.toString());
+    }
+
+    @Test
+    public void testWrite_withGedcomAndOutputStream() {
+        Header header = new Header();
+        header.setLanguage("English");
+        header.setCopyright("2019");
+
+        Gedcom gedcom = new Gedcom();
+        gedcom.setHeader(header);
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        JsonParser jsonParser = new JsonParser();
+        jsonParser.write(gedcom, os);
+
+        assertGedcomJson(gedcom, os.toString());
+    }
+
+    @Test
+    public void testWrite_withGedcomTagsAndWriter() {
+        GedcomTag tag = new GedcomTag("", "head", "");
+
+        Writer writer = new StringWriter();
+        JsonParser jsonParser = new JsonParser();
+        jsonParser.write(Collections.singletonList(tag), writer);
+
+        assertGedcomTagsJson(writer.toString());
+    }
+
+    @Test
+    public void testWrite_withGedcomTagsAndOutputStream() {
+        GedcomTag tag = new GedcomTag("", "head", "");
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        JsonParser jsonParser = new JsonParser();
+        jsonParser.write(Collections.singletonList(tag), os);
+
+        assertGedcomTagsJson(os.toString());
+    }
+
+    private void assertGedcomJson(Gedcom gedcom, String json) {
+        JsonParser jsonParser = new JsonParser();
+        Gedcom actualGedcom = jsonParser.fromJson(json);
+        assertNotNull(actualGedcom);
+        assertEquals(gedcom.getHeader().getLanguage(), actualGedcom.getHeader().getLanguage());
+        assertEquals(gedcom.getHeader().getCopyright(), actualGedcom.getHeader().getCopyright());
+    }
+
+    private void assertGedcomTagsJson(String json) {
+        com.google.gson.JsonParser gsonParser = new com.google.gson.JsonParser();
+        JsonElement jsonElement = gsonParser.parse(json);
+        assertNotNull(jsonElement);
+        assertTrue(jsonElement.isJsonArray());
+
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
+
+        JsonElement head = jsonArray.get(0);
+        assertNotNull(head);
+        assertTrue(head.isJsonObject());
+
+        JsonObject headObj = head.getAsJsonObject();
+
+        JsonElement jsonTag = headObj.get("tag");
+        assertNotNull(jsonTag);
+        assertTrue(jsonTag.isJsonPrimitive());
+        assertEquals("head", jsonTag.getAsString());
+    }
+
+}

--- a/src/test/java/org/folg/gedcom/parser/ModelParserTest.java
+++ b/src/test/java/org/folg/gedcom/parser/ModelParserTest.java
@@ -4,6 +4,9 @@ import org.folg.gedcom.model.*;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URL;
 
 import static org.testng.Assert.assertEquals;
@@ -19,6 +22,8 @@ public class ModelParserTest {
 
     Gedcom gedcom = modelParser.parseGedcom(gedcomFile);
     assertNotNull(gedcom);
+
+    gedcom.createIndexes();
 
     assertNotNull(gedcom.getHeader());
     assertNotNull(gedcom.getHeader().getGenerator());
@@ -40,7 +45,7 @@ public class ModelParserTest {
     assertEquals(generatorCorporation.getFax(), "866-111-1111");
     assertEquals(generatorCorporation.getWww(), "http://www.mycorporation.org/");
 
-    Submitter submitter = gedcom.getSubmitter();
+    Submitter submitter = gedcom.getSubmitter("SUB1");
     assertNotNull(submitter);
     assertEquals(submitter.getAddress().getValue()
       , "5000 MyCorpCampus Dr\n" +
@@ -117,4 +122,31 @@ public class ModelParserTest {
     assertEquals(repository.getFax(), "866-111-1111");
     assertEquals(repository.getWww(), "https://www.mycorporation.com/");
   }
+
+  @Test
+  public void testParse_withInputStream() throws Exception {
+    URL gedcomUrl = this.getClass().getClassLoader().getResource("Case001-AddressStructure.ged");
+    ModelParser modelParser = new ModelParser();
+
+    InputStream is = gedcomUrl.openStream();
+    assertNotNull(is);
+
+    Gedcom gedcom = modelParser.parseGedcom(is);
+    assertNotNull(gedcom);
+  }
+
+  @Test
+  public void testParse_withReader() throws Exception {
+    URL gedcomUrl = this.getClass().getClassLoader().getResource("Case001-AddressStructure.ged");
+    ModelParser modelParser = new ModelParser();
+
+    InputStream is = gedcomUrl.openStream();
+    assertNotNull(is);
+
+    Reader reader = new InputStreamReader(is, "UTF-8");
+
+    Gedcom gedcom = modelParser.parseGedcom(reader);
+    assertNotNull(gedcom);
+  }
+
 }

--- a/src/test/java/org/folg/gedcom/parser/TreeParserTest.java
+++ b/src/test/java/org/folg/gedcom/parser/TreeParserTest.java
@@ -1,0 +1,73 @@
+package org.folg.gedcom.parser;
+
+import org.folg.gedcom.model.GedcomTag;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TreeParserTest {
+
+    @Test
+    public void testParse_withFile() throws Exception {
+        URL gedcomUrl = this.getClass().getClassLoader().getResource("Case001-AddressStructure.ged");
+        File gedcomFile = new File(gedcomUrl.toURI());
+        TreeParser treeParser = new TreeParser();
+
+        List<GedcomTag> gedcomTags = treeParser.parseGedcom(gedcomFile);
+        assertNotNull(gedcomTags);
+        assertEquals(4, gedcomTags.size());
+
+        GedcomTag headTag = gedcomTags.get(0);
+        assertNotNull(headTag);
+        assertEquals("HEAD", headTag.getTag());
+
+        GedcomTag submissionTag = gedcomTags.get(1);
+        assertNotNull(submissionTag);
+        assertEquals("SUBM", submissionTag.getTag());
+
+        GedcomTag individualTag = gedcomTags.get(2);
+        assertNotNull(individualTag);
+        assertEquals("INDI", individualTag.getTag());
+
+        GedcomTag repoTag = gedcomTags.get(3);
+        assertNotNull(repoTag);
+        assertEquals("REPO", repoTag.getTag());
+    }
+
+    @Test
+    public void testParse_withInputStream() throws Exception {
+        URL gedcomUrl = this.getClass().getClassLoader().getResource("Case001-AddressStructure.ged");
+        TreeParser treeParser = new TreeParser();
+
+        InputStream is = gedcomUrl.openStream();
+        assertNotNull(is);
+
+        List<GedcomTag> gedcomTags = treeParser.parseGedcom(is);
+        assertNotNull(gedcomTags);
+        assertEquals(4, gedcomTags.size());
+    }
+
+    @Test
+    public void testParse_withReader() throws Exception {
+        URL gedcomUrl = this.getClass().getClassLoader().getResource("Case001-AddressStructure.ged");
+        TreeParser treeParser = new TreeParser();
+
+        InputStream is = gedcomUrl.openStream();
+        assertNotNull(is);
+
+        Reader reader = new InputStreamReader(is, "UTF-8");
+
+        List<GedcomTag> gedcomTags = treeParser.parseGedcom(reader);
+        assertNotNull(gedcomTags);
+        assertEquals(4, gedcomTags.size());
+    }
+
+}

--- a/src/test/java/org/folg/gedml/GedcomParserTest.java
+++ b/src/test/java/org/folg/gedml/GedcomParserTest.java
@@ -1,0 +1,220 @@
+package org.folg.gedml;
+
+import org.gedml.GedcomParser;
+import org.testng.annotations.Test;
+import org.xml.sax.*;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class GedcomParserTest {
+
+    class MockContentHandler implements ContentHandler {
+
+        final List<String> tags;
+
+        MockContentHandler() {
+            this.tags = new ArrayList<String>();
+        }
+
+        @Override
+        public void setDocumentLocator(Locator locator) {
+
+        }
+
+        @Override
+        public void startDocument() {
+
+        }
+
+        @Override
+        public void endDocument() {
+
+        }
+
+        @Override
+        public void startPrefixMapping(String prefix, String uri) {
+
+        }
+
+        @Override
+        public void endPrefixMapping(String prefix) {
+
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes atts) {
+            this.tags.add(localName);
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) {
+
+        }
+
+        @Override
+        public void characters(char[] ch, int start, int length) {
+
+        }
+
+        @Override
+        public void ignorableWhitespace(char[] ch, int start, int length) {
+
+        }
+
+        @Override
+        public void processingInstruction(String target, String data) {
+
+        }
+
+        @Override
+        public void skippedEntity(String name) {
+
+        }
+
+    }
+
+    class MockErrorHandler implements ErrorHandler {
+
+        @Override
+        public void warning(SAXParseException exception) {
+
+        }
+
+        @Override
+        public void error(SAXParseException exception) {
+
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) {
+
+        }
+    }
+
+    class MockReader extends Reader {
+
+        private final StringReader internalReader;
+        boolean readWasCalled = false;
+        boolean closeWasCalled = false;
+
+        MockReader(String chars) {
+            this.internalReader = new StringReader(chars);
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            this.readWasCalled = true;
+            return internalReader.read(cbuf, off, len);
+        }
+
+        @Override
+        public void close() {
+            this.closeWasCalled = true;
+            internalReader.close();
+        }
+    }
+
+    class MockInputStream extends InputStream {
+
+        private final ByteArrayInputStream internalStream;
+        boolean readWasCalled = false;
+
+        MockInputStream(String chars) {
+            this.internalStream = new ByteArrayInputStream(chars.getBytes(Charset.forName("UTF-8")));
+        }
+
+        @Override
+        public int read() {
+            this.readWasCalled = true;
+            return internalStream.read();
+        }
+    }
+
+    @Test
+    public void testParse_withInputSourceAndCharacterStream() throws Exception {
+        MockContentHandler contentHandler = new MockContentHandler();
+        MockErrorHandler errorHandler = new MockErrorHandler();
+
+        String mockSystemId = "Mock system Id";
+        MockReader characterStream = new MockReader("0 HEAD\n1 CHAR UTF-8\n0 @I1@ INDI\n");
+        MockInputStream byteStream = new MockInputStream("I should not get called!");
+        InputSource input = new InputSource();
+        input.setCharacterStream(characterStream);
+        input.setByteStream(byteStream);
+        input.setSystemId(mockSystemId);
+
+        GedcomParser parser = new GedcomParser();
+        parser.setContentHandler(contentHandler);
+        parser.setErrorHandler(errorHandler);
+        parser.parse(input);
+
+        assertTrue(characterStream.readWasCalled, "Failed to read character stream");
+        assertTrue(characterStream.closeWasCalled, "Failed to close character stream");
+        assertFalse(byteStream.readWasCalled, "Should not have read byte stream");
+        assertEquals(parser.getSystemId(), mockSystemId);
+
+        assertEquals(contentHandler.tags, Arrays.asList("GED", "HEAD", "CHAR", "INDI"));
+    }
+
+    @Test
+    public void testParse_withInputSourceAndByteStream() throws Exception {
+        MockContentHandler contentHandler = new MockContentHandler();
+        MockErrorHandler errorHandler = new MockErrorHandler();
+
+        String mockSystemId = "Mock system Id";
+        MockReader characterStream = new MockReader("I should not get called!");
+        MockInputStream byteStream = new MockInputStream("0 HEAD\n1 CHAR UTF-8\n0 @I1@ INDI\n");
+        InputSource input = new InputSource();
+        input.setByteStream(byteStream);
+        input.setSystemId(mockSystemId);
+
+        GedcomParser parser = new GedcomParser();
+        parser.setContentHandler(contentHandler);
+        parser.setErrorHandler(errorHandler);
+        parser.parse(input);
+
+        assertFalse(characterStream.readWasCalled, "Should not have read character stream");
+        assertFalse(characterStream.closeWasCalled, "Should not have closed character stream");
+        assertTrue(byteStream.readWasCalled, "Failed to read byte stream");
+        assertEquals(parser.getSystemId(), mockSystemId);
+
+        assertEquals(contentHandler.tags, Arrays.asList("GED", "HEAD", "CHAR", "INDI"));
+    }
+
+    @Test
+    public void testParse_withInputSourceAndSystemId() throws Exception {
+        MockContentHandler contentHandler = new MockContentHandler();
+        MockErrorHandler errorHandler = new MockErrorHandler();
+
+        URL gedcomUrl = this.getClass().getClassLoader().getResource("Case001-AddressStructure.ged");
+        String expectedSystemId = gedcomUrl.toString();
+        MockReader characterStream = new MockReader("I should not get called!");
+        MockInputStream byteStream = new MockInputStream("0 HEAD\n1 CHAR UTF-8\n0 @I1@ INDI\n");
+        InputSource input = new InputSource();
+        input.setSystemId(expectedSystemId);
+
+        GedcomParser parser = new GedcomParser();
+        parser.setContentHandler(contentHandler);
+        parser.setErrorHandler(errorHandler);
+        parser.parse(input);
+
+        assertFalse(characterStream.readWasCalled, "Should not have read character stream");
+        assertFalse(characterStream.closeWasCalled, "Should not have closed character stream");
+        assertFalse(byteStream.readWasCalled, "Failed to read byte stream");
+        assertEquals(parser.getSystemId(), expectedSystemId);
+
+        assertEquals(contentHandler.tags.size(), 91);
+        assertEquals(contentHandler.tags.get(0), "GED");
+        assertEquals(contentHandler.tags.get(1), "HEAD");
+    }
+
+}


### PR DESCRIPTION
All parsers now accept both InputStreams and Readers; JsonParser can write to Writer and OutputStream; tests.   Sorry for full whitespace reformat on GedcomParser.