### PR TITLE
Updates to Ansel conversions based on FamilySearch extensions

### DIFF
--- a/src/main/java/org/gedml/AnselInputStreamReader.java
+++ b/src/main/java/org/gedml/AnselInputStreamReader.java
@@ -40,7 +40,7 @@ public class AnselInputStreamReader extends InputStreamReader
         if (b<128) return b;   // return ASCII characters unchanged
 
         // try to match two ansel chars if we can
-        if (pending>0 && b>=0xE0 && b<=0xFF) {
+        if (pending>0 && ((b>=0xE0 && b<=0xFF) || (b>=0xd7 && b<=0xd9))) {
             int u = convert2(b*256 + pending);
             if (u>0) {
                 pending = input.read();
@@ -160,6 +160,11 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xC7: return 0x00DF;  // eszett symbol
             case 0xC8: return 0x20AC;  // euro sign
             case 0xE8: return 0x0308;  // umlaut, diaresis
+            // FamilySearch Extensions
+            case 0xBE: return 0x25AF;  // white vertical rectangle
+            case 0xBF: return 0x25AE;  // black vertical rectangle
+            case 0xCD: return 0x0065;  // e in middle of line
+            case 0xCE: return 0x006F;  // o in middle of line
 
             default: return 0xFFFD;     // if no match, use Unicode REPLACEMENT CHARACTER
         } //end switch
@@ -172,6 +177,7 @@ public class AnselInputStreamReader extends InputStreamReader
     private int convert2( int ansel )
     {
         switch(ansel) {
+            case 0xE020: return 0x02C0;  //  modifier letter glottal stop
             case 0xE041: return 0x1EA2;  //  capital a with hook above
             case 0xE045: return 0x1EBA;  //  capital e with hook above
             case 0xE049: return 0x1EC8;  //  capital i with hook above
@@ -184,6 +190,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE06F: return 0x1ECF;  //  small o with hook above
             case 0xE075: return 0x1EE7;  //  small u with hook above
             case 0xE079: return 0x1EF7;  //  small y with hook above
+            case 0xE120: return 0x02CB;  //  modifier letter grave accent
             case 0xE141: return 0x00C0;  //  capital A with grave accent
             case 0xE145: return 0x00C8;  //  capital E with grave accent
             case 0xE149: return 0x00CC;  //  capital I with grave accent
@@ -198,6 +205,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE175: return 0x00F9;  //  small u with grave accent
             case 0xE177: return 0x1E81;  //  small w with grave
             case 0xE179: return 0x1EF3;  //  small y with grave
+            case 0xE220: return 0x02CA;  //  modifier letter acute accent
             case 0xE241: return 0x00C1;  //  capital A with acute accent
             case 0xE243: return 0x0106;  //  capital C with acute accent
             case 0xE245: return 0x00C9;  //  capital E with acute accent
@@ -234,6 +242,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE27A: return 0x017A;  //  small z with acute accent
             case 0xE2A5: return 0x01FC;  //  capital ae with acute
             case 0xE2B5: return 0x01FD;  //  small ae with acute
+            case 0xE320: return 0x02C6;  //  modifier letter circumflex accent
             case 0xE341: return 0x00C2;  //  capital A with circumflex accent
             case 0xE343: return 0x0108;  //  capital c with circumflex
             case 0xE345: return 0x00CA;  //  capital E with circumflex accent
@@ -260,6 +269,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE377: return 0x0175;  //  small w with circumflex
             case 0xE379: return 0x0177;  //  small y with circumflex
             case 0xE37A: return 0x1E91;  //  small z with circumflex
+            case 0xE420: return 0x02DC;  //  small tilde
             case 0xE441: return 0x00C3;  //  capital A with tilde
             case 0xE445: return 0x1EBC;  //  capital e with tilde
             case 0xE449: return 0x0128;  //  capital i with tilde
@@ -276,6 +286,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE475: return 0x0169;  //  small u with tilde
             case 0xE476: return 0x1E7D;  //  small v with tilde
             case 0xE479: return 0x1EF9;  //  small y with tilde
+            case 0xE520: return 0x02C9;  //  modifier letter macron
             case 0xE541: return 0x0100;  //  capital a with macron
             case 0xE545: return 0x0112;  //  capital e with macron
             case 0xE547: return 0x1E20;  //  capital g with macron
@@ -290,6 +301,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE575: return 0x016B;  //  small u with macron
             case 0xE5A5: return 0x01E2;  //  capital ae with macron
             case 0xE5B5: return 0x01E3;  //  small ae with macron
+            case 0xE620: return 0x02D8;  //  breve
             case 0xE641: return 0x0102;  //  capital A with breve
             case 0xE645: return 0x0114;  //  capital e with breve
             case 0xE647: return 0x011E;  //  capital g with breve
@@ -302,6 +314,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE669: return 0x012D;  //  small i with breve
             case 0xE66F: return 0x014F;  //  small o with breve
             case 0xE675: return 0x016D;  //  small u with breve
+            case 0xE720: return 0x02D9;  //  dot above
             case 0xE742: return 0x1E02;  //  capital b with dot above
             case 0xE743: return 0x010A;  //  capital c with dot above
             case 0xE744: return 0x1E0A;  //  capital d with dot above
@@ -337,6 +350,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE778: return 0x1E8B;  //  small x with dot above
             case 0xE779: return 0x1E8F;  //  small y with dot above
             case 0xE77A: return 0x017C;  //  small z with dot above
+            case 0xE820: return 0x00A8;  //  diaeresis
             case 0xE841: return 0x00C4;  //  capital A with diaeresis
             case 0xE845: return 0x00CB;  //  capital E with diaeresis
             case 0xE848: return 0x1E26;  //  capital h with diaeresis
@@ -356,6 +370,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE877: return 0x1E85;  //  small w with diaeresis
             case 0xE878: return 0x1E8D;  //  small x with diaeresis
             case 0xE879: return 0x00FF;  //  small y with diaeresis
+            case 0xE920: return 0x02C7;  //  caron
             case 0xE941: return 0x01CD;  //  capital a with caron
             case 0xE943: return 0x010C;  //  capital C with caron
             case 0xE944: return 0x010E;  //  capital D with caron
@@ -387,12 +402,15 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xE974: return 0x0165;  //  small t with caron
             case 0xE975: return 0x01D4;  //  small u with caron
             case 0xE97A: return 0x017E;  //  small z with caron
+            case 0xEA20: return 0x02DA;  //  ring above
             case 0xEA41: return 0x00C5;  //  capital A with ring above
             case 0xEA61: return 0x00E5;  //  small a with ring above
             case 0xEA75: return 0x016F;  //  small u with ring above
             case 0xEA77: return 0x1E98;  //  small w with ring above
             case 0xEA79: return 0x1E99;  //  small y with ring above
             case 0xEAAD: return 0x016E;  //  capital U with ring above
+            case 0xED20: return 0x02BC;  //  modifier letter apostrophe
+            case 0xEE20: return 0x02DD;  //  double acute accent
             case 0xEE4F: return 0x0150;  //  capital O with double acute
             case 0xEE55: return 0x0170;  //  capital U with double acute
             case 0xEE6F: return 0x0151;  //  small o with double acute
@@ -418,6 +436,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xF072: return 0x0157;  //  small r with cedilla
             case 0xF073: return 0x015F;  //  small s with cedilla
             case 0xF074: return 0x0163;  //  small t with cedilla
+            case 0xF120: return 0x02DB;  //  ogonek
             case 0xF141: return 0x0104;  //  capital A with ogonek
             case 0xF145: return 0x0118;  //  capital E with ogonek
             case 0xF149: return 0x012E;  //  capital i with ogonek
@@ -470,8 +489,199 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xF375: return 0x1E73;  //  small u with diaeresis below
             case 0xF441: return 0x1E00;  //  capital a with ring below
             case 0xF461: return 0x1E01;  //  small a with ring below
+            case 0xF520: return 0x2017;  //  double line below
             case 0xF948: return 0x1E2A;  //  capital h with breve below
             case 0xF968: return 0x1E2B;  //  small h with breve below
+            // FamilySearch Extensions
+            case 0xFC20: return 0x002F;  //  space with diagonal stroke
+            case 0xFC41: return 0x023A;  //  capital A with diagonal stroke
+            case 0xFC43: return 0x023B;  //  capital C with diagonal stroke
+            case 0xFC45: return 0x0246;  //  capital E with diagonal stroke
+            case 0xFC4B: return 0xA742;  //  capital K with diagonal stroke
+            case 0xFC4C: return 0x0141;  //  capital L with diagonal stroke
+            case 0xFC4F: return 0x00D8;  //  capital O with diagonal stroke
+            case 0xFC51: return 0xA758;  //  capital Q with diagonal stroke
+            case 0xFC54: return 0x023E;  //  capital T with diagonal stroke
+            case 0xFC56: return 0xA75E;  //  capital V with diagonal stroke
+            case 0xFC61: return 0x2C65;  //  small a with diagonal stroke
+            case 0xFC63: return 0x023C;  //  small c with diagonal stroke
+            case 0xFC65: return 0x0247;  //  small e with diagonal stroke
+            case 0xFC6B: return 0xA743;  //  small k with diagonal stroke
+            case 0xFC6C: return 0x0142;  //  small l with diagonal stroke
+            case 0xFC6F: return 0x00F8;  //  small o with diagonal stroke
+            case 0xFC71: return 0xA759;  //  small q with diagonal stroke
+            case 0xFC74: return 0x2C66;  //  small t with diagonal stroke
+            case 0xFC76: return 0xA75F;  //  small v with diagonal stroke
+            case 0xD741: return 0x2550;	 // box drawings double horizontal
+            case 0xD742: return 0x2551;	 // box drawings double vertical
+            case 0xD743: return 0x2557;	 // box drawings double down and left
+            case 0xD744: return 0x255D;	 // box drawings double up and left
+            case 0xD745: return 0x255A;	 // box drawings double up and right
+            case 0xD746: return 0x2554;	 // box drawings double down and right
+            case 0xD747: return 0x2563;	 // box drawings double vertical and left
+            case 0xD748: return 0x2569;	 // box drawings double up and horizontal
+            case 0xD749: return 0x2560;	 // box drawings double vertical and right
+            case 0xD74A: return 0x2566;	 // box drawings double down and horizontal
+            case 0xD74B: return 0x256C;	 // box drawings double vertical and horizontal
+            case 0xD74C: return 0x2562;	 // box drawings double vertical and single left
+            case 0xD74D: return 0x2567;	 // box drawings single up and double horizontal
+            case 0xD74E: return 0x255F;	 // box drawings double vertical and single right
+            case 0xD74F: return 0x2564;	 // box drawings single down and double horizontal
+            case 0xD750: return 0x2561;	 // box drawings single vertical and double left
+            case 0xD751: return 0x2568;	 // box drawings double up and single horizontal
+            case 0xD752: return 0x255E;	 // box drawings single vertical and double right
+            case 0xD753: return 0x2565;	 // box drawings double down and single horizontal
+            case 0xD754: return 0x256A;	 // box drawings single vertical and double horizontal
+            case 0xD755: return 0x2591;	 // light shade - 25%
+            case 0xD756: return 0x2592;	 // medium shade - 50%
+            case 0xD757: return 0x2593;	 // dark shade - 75%
+            case 0xD758: return 0x2588;	 // full block
+            case 0xD761: return 0x2500;	 // box drawings light horizontal
+            case 0xD762: return 0x2502;	 // box drawings light vertical
+            case 0xD763: return 0x2510;	 // box drawings light down and left
+            case 0xD764: return 0x2518;	 // box drawings light up and left
+            case 0xD765: return 0x2514;	 // box drawings light up and right
+            case 0xD766: return 0x250C;	 // box drawings light down and right
+            case 0xD767: return 0x2524;	 // box drawings light vertical and left
+            case 0xD768: return 0x2534;	 // box drawings light up and horizontal
+            case 0xD769: return 0x251C;	 // box drawings light vertical and right
+            case 0xD76A: return 0x252C;	 // box drawings light down and horizontal
+            case 0xD76B: return 0x253C;	 // box drawings light vertical and horizontal
+            case 0xD76C: return 0x2555;	 // box drawings light single down and double left
+            case 0xD76D: return 0x255B;	 // box drawings light single up and double left
+            case 0xD76E: return 0x2558;	 // box drawings light single up and double right
+            case 0xD76F: return 0x2552;	 // box drawings light single down and double right
+            case 0xD770: return 0x2556;	 // box drawings light double down and single left
+            case 0xD771: return 0x255C;	 // box drawings light double up and single left
+            case 0xD772: return 0x2559;	 // box drawings light double up and single right
+            case 0xD773: return 0x2553;	 // box drawings light double down and single right
+            case 0xD774: return 0x256B;	 // box drawings light double vertical and single horizontal
+            case 0xD775: return 0x258C;	 // left half block
+            case 0xD776: return 0x2580;	 // upper half block
+            case 0xD777: return 0x2590;	 // right half block
+            case 0xD778: return 0x2584;	 // lower half block
+            case 0xD779: return 0x25AA;	 // black small square
+            case 0xD824: return 0x03C2;	 // Greek small letter final sigma
+            case 0xD841: return 0x0391;	 // Greek capital letter alpha
+            case 0xD842: return 0x0392;	 // Greek capital letter beta
+            case 0xD843: return 0x03A5;	 // Greek capital letter upsilon
+            case 0xD844: return 0x0394;	 // Greek capital letter delta
+            case 0xD845: return 0x0395;	 // Greek capital letter epsilon
+            case 0xD846: return 0x03A6;	 // Greek capital letter phi
+            case 0xD847: return 0x0393;	 // Greek capital letter gamma
+            case 0xD848: return 0x03A8;	 // Greek capital letter psi
+            case 0xD849: return 0x0399;	 // Greek capital letter iota
+            case 0xD84B: return 0x039A;	 // Greek capital letter kappa
+            case 0xD84C: return 0x039B;	 // Greek capital letter lamda
+            case 0xD84D: return 0x039C;	 // Greek capital letter mu
+            case 0xD84E: return 0x039D;	 // Greek capital letter nu
+            case 0xD84F: return 0x039F;	 // Greek capital letter omicron
+            case 0xD850: return 0x03A0;	 // Greek capital letter pi
+            case 0xD851: return 0x03A7;	 // Greek capital letter chi
+            case 0xD852: return 0x03A1;	 // Greek capital letter rho
+            case 0xD853: return 0x03A3;	 // Greek capital letter sigma
+            case 0xD854: return 0x03A4;	 // Greek capital letter tau
+            case 0xD855: return 0x03A9;	 // Greek capital letter omega
+            case 0xD856: return 0x0398;	 // Greek capital letter theta
+            case 0xD857: return 0x0397;	 // Greek capital letter eta
+            case 0xD858: return 0x039E;	 // Greek capital letter xi
+            case 0xD85A: return 0x0396;	 // Greek capital letter zeta
+            case 0xD861: return 0x03B1;	 // Greek small letter alpha
+            case 0xD862: return 0x03B2;	 // Greek small letter beta
+            case 0xD863: return 0x03C5;	 // Greek small letter upsilon
+            case 0xD864: return 0x03B4;	 // Greek small letter delta
+            case 0xD865: return 0x03B5;	 // Greek small letter epsilon
+            case 0xD866: return 0x03C6;	 // Greek small letter phi
+            case 0xD867: return 0x03B3;	 // Greek small letter gamma
+            case 0xD868: return 0x03C8;	 // Greek small letter psi
+            case 0xD869: return 0x03B9;	 // Greek small letter iota
+            case 0xD86B: return 0x03BA;	 // Greek small letter kappa
+            case 0xD86C: return 0x03BB;	 // Greek small letter lamda
+            case 0xD86D: return 0x03BC;	 // Greek small letter mu
+            case 0xD86E: return 0x03BD;	 // Greek small letter nu
+            case 0xD86F: return 0x03BF;	 // Greek small letter omicron
+            case 0xD870: return 0x03C0;	 // Greek small letter pi
+            case 0xD871: return 0x03C7;	 // Greek small letter chi
+            case 0xD872: return 0x03C1;	 // Greek small letter rho
+            case 0xD873: return 0x03C3;	 // Greek small letter sigma
+            case 0xD874: return 0x03C4;	 // Greek small letter tau
+            case 0xD875: return 0x03C9;	 // Greek small letter omega
+            case 0xD876: return 0x03B8;	 // Greek small letter theta
+            case 0xD877: return 0x03B7;	 // Greek small letter eta
+            case 0xD878: return 0x03BE;	 // Greek small letter xi
+            case 0xD87A: return 0x03B6;	 // Greek small letter zeta
+            case 0xD920: return 0x0E3F;	 // Thai currency symbol baht
+            case 0xD921: return 0x00A2;	 // cent sign
+            case 0xD922: return 0x00A5;	 // yen sign
+            case 0xD923: return 0x20A7;	 // peseta sign
+            case 0xD924: return 0x0192;	 // florin currency sign
+            case 0xD925: return 0x00A4;	 // currency sign
+            case 0xD926: return 0x20A4;	 // lira sign
+            case 0xD927: return 0x20A0;	 // Euro-currency sign
+            case 0xD928: return 0x20A1;	 // colon sign
+            case 0xD929: return 0x20A2;	 // cruzeiro sign
+            case 0xD92A: return 0x20A3;	 // French franc sign
+            case 0xD92B: return 0x20A5;	 // mill sign
+            case 0xD92C: return 0x20A6;	 // naira sign
+            case 0xD92D: return 0x20A8;	 // rupee sign
+            case 0xD92E: return 0x20A9;	 // won sign
+            case 0xD92F: return 0x20AA;	 // new sheqel sign
+            case 0xD930: return 0x20AC;	 // Euro sign
+            case 0xD931: return 0x00B9;	 // superscript one
+            case 0xD932: return 0x00B2;	 // superscript two
+            case 0xD933: return 0x00B3;	 // superscript three
+            case 0xD941: return 0x00AA;	 // feminine ordinal indicator
+            case 0xD942: return 0x00BA;	 // masculine ordinal indicator
+            case 0xD943: return 0x00AB;	 // left-pointing double angle quotation mark
+            case 0xD944: return 0x00BB;	 // right-pointing double angle quotation mark
+            case 0xD945: return 0x00A6;	 // broken vertical bar
+            case 0xD946: return 0x00B6;	 // pilcrow/paragraph sign
+            case 0xD947: return 0x00A7;	 // section sign
+            case 0xD948: return 0x2310;	 // reversed not sign
+            case 0xD949: return 0x2020;	 // dagger
+            case 0xD94A: return 0x2021;	 // double dagger
+            case 0xD94C: return 0x2122;	 // trade mark sign
+            case 0xD94D: return 0xFB01;	 // Latin small ligature fi
+            case 0xD94E: return 0xFB02;	 // Latin small ligature fl
+            case 0xD94F: return 0x2039;	 // left-pointing single angle quotation mark
+            case 0xD950: return 0x203A;	 // right-pointing single angle quotation mark
+            case 0xD951: return 0x2030;	 // per mille sign
+            case 0xD952: return 0x2026;	 // horizontal ellipsis
+            case 0xD953: return 0x201C;	 // left double quotation mark
+            case 0xD954: return 0x201D;	 // right double quotation mark
+            case 0xD955: return 0x201A;	 // single low-9 quotation mark
+            case 0xD956: return 0x201E;	 // double low-9 quotation mark
+            case 0xD957: return 0x2022;	 // bullet
+            case 0xD958: return 0x2013;	 // en dash
+            case 0xD959: return 0x00A0;	 // no-break space
+            case 0xD95A: return 0x00B5;	 // micro sign
+            case 0xD961: return 0x00BD;	 // vulgar fraction one half
+            case 0xD962: return 0x00BC;	 // vulgar fraction one quarter
+            case 0xD963: return 0x00BE;	 // vulgar fraction three quarters
+            case 0xD964: return 0x221E;	 // infinity
+            case 0xD965: return 0x2205;	 // empty set
+            case 0xD966: return 0x2208;	 // element of
+            case 0xD967: return 0x2229;	 // intersection
+            case 0xD968: return 0x00AC;	 // not sign
+            case 0xD969: return 0x2261;	 // identical to
+            case 0xD96A: return 0x00D7;	 // multiplication sign
+            case 0xD96B: return 0x2265;	 // greater-than or equal to
+            case 0xD96C: return 0x2264;	 // less-than or equal to
+            case 0xD96D: return 0x00F7;	 // division sign
+            case 0xD96E: return 0x2248;	 // almost equal to
+            case 0xD96F: return 0x22C5;	 // dot operator
+            case 0xD970: return 0x2320;	 // top half integral
+            case 0xD971: return 0x2321;	 // bottom half integral
+            case 0xD972: return 0x221A;	 // square root
+            case 0xD973: return 0x2044;	 // fraction/division slash
+            case 0xD974: return 0x2018;	 // left single quotation mark
+            case 0xD975: return 0x2019;	 // right single quotation mark
+            case 0xD976: return 0x2014;	 // em dash
+            case 0xD977: return 0x00AD;	 // soft hyphen
+            case 0xD979: return 0x20AD;	 // kip sign
+            case 0xD97A: return 0x20AE;	 // tugrik sign
+            case 0xD97B: return 0x20AF;	 // drachma sign
+            case 0xD97C: return 0x20AB;	 // dong sign
 
             default: return -1;
         } //end switch

--- a/src/main/java/org/gedml/AnselInputStreamReader.java
+++ b/src/main/java/org/gedml/AnselInputStreamReader.java
@@ -493,7 +493,7 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xF948: return 0x1E2A;  //  capital h with breve below
             case 0xF968: return 0x1E2B;  //  small h with breve below
             // FamilySearch Extensions
-            case 0xFC20: return 0x002F;  //  space with diagonal stroke
+            case 0xFC20: return 0x0338;  //  space with diagonal stroke
             case 0xFC41: return 0x023A;  //  capital A with diagonal stroke
             case 0xFC43: return 0x023B;  //  capital C with diagonal stroke
             case 0xFC45: return 0x0246;  //  capital E with diagonal stroke
@@ -512,176 +512,176 @@ public class AnselInputStreamReader extends InputStreamReader
             case 0xFC71: return 0xA759;  //  small q with diagonal stroke
             case 0xFC74: return 0x2C66;  //  small t with diagonal stroke
             case 0xFC76: return 0xA75F;  //  small v with diagonal stroke
-            case 0xD741: return 0x2550;	 // box drawings double horizontal
-            case 0xD742: return 0x2551;	 // box drawings double vertical
-            case 0xD743: return 0x2557;	 // box drawings double down and left
-            case 0xD744: return 0x255D;	 // box drawings double up and left
-            case 0xD745: return 0x255A;	 // box drawings double up and right
-            case 0xD746: return 0x2554;	 // box drawings double down and right
-            case 0xD747: return 0x2563;	 // box drawings double vertical and left
-            case 0xD748: return 0x2569;	 // box drawings double up and horizontal
-            case 0xD749: return 0x2560;	 // box drawings double vertical and right
-            case 0xD74A: return 0x2566;	 // box drawings double down and horizontal
-            case 0xD74B: return 0x256C;	 // box drawings double vertical and horizontal
-            case 0xD74C: return 0x2562;	 // box drawings double vertical and single left
-            case 0xD74D: return 0x2567;	 // box drawings single up and double horizontal
-            case 0xD74E: return 0x255F;	 // box drawings double vertical and single right
-            case 0xD74F: return 0x2564;	 // box drawings single down and double horizontal
-            case 0xD750: return 0x2561;	 // box drawings single vertical and double left
-            case 0xD751: return 0x2568;	 // box drawings double up and single horizontal
-            case 0xD752: return 0x255E;	 // box drawings single vertical and double right
-            case 0xD753: return 0x2565;	 // box drawings double down and single horizontal
-            case 0xD754: return 0x256A;	 // box drawings single vertical and double horizontal
-            case 0xD755: return 0x2591;	 // light shade - 25%
-            case 0xD756: return 0x2592;	 // medium shade - 50%
-            case 0xD757: return 0x2593;	 // dark shade - 75%
-            case 0xD758: return 0x2588;	 // full block
-            case 0xD761: return 0x2500;	 // box drawings light horizontal
-            case 0xD762: return 0x2502;	 // box drawings light vertical
-            case 0xD763: return 0x2510;	 // box drawings light down and left
-            case 0xD764: return 0x2518;	 // box drawings light up and left
-            case 0xD765: return 0x2514;	 // box drawings light up and right
-            case 0xD766: return 0x250C;	 // box drawings light down and right
-            case 0xD767: return 0x2524;	 // box drawings light vertical and left
-            case 0xD768: return 0x2534;	 // box drawings light up and horizontal
-            case 0xD769: return 0x251C;	 // box drawings light vertical and right
-            case 0xD76A: return 0x252C;	 // box drawings light down and horizontal
-            case 0xD76B: return 0x253C;	 // box drawings light vertical and horizontal
-            case 0xD76C: return 0x2555;	 // box drawings light single down and double left
-            case 0xD76D: return 0x255B;	 // box drawings light single up and double left
-            case 0xD76E: return 0x2558;	 // box drawings light single up and double right
-            case 0xD76F: return 0x2552;	 // box drawings light single down and double right
-            case 0xD770: return 0x2556;	 // box drawings light double down and single left
-            case 0xD771: return 0x255C;	 // box drawings light double up and single left
-            case 0xD772: return 0x2559;	 // box drawings light double up and single right
-            case 0xD773: return 0x2553;	 // box drawings light double down and single right
-            case 0xD774: return 0x256B;	 // box drawings light double vertical and single horizontal
-            case 0xD775: return 0x258C;	 // left half block
-            case 0xD776: return 0x2580;	 // upper half block
-            case 0xD777: return 0x2590;	 // right half block
-            case 0xD778: return 0x2584;	 // lower half block
-            case 0xD779: return 0x25AA;	 // black small square
-            case 0xD824: return 0x03C2;	 // Greek small letter final sigma
-            case 0xD841: return 0x0391;	 // Greek capital letter alpha
-            case 0xD842: return 0x0392;	 // Greek capital letter beta
-            case 0xD843: return 0x03A5;	 // Greek capital letter upsilon
-            case 0xD844: return 0x0394;	 // Greek capital letter delta
-            case 0xD845: return 0x0395;	 // Greek capital letter epsilon
-            case 0xD846: return 0x03A6;	 // Greek capital letter phi
-            case 0xD847: return 0x0393;	 // Greek capital letter gamma
-            case 0xD848: return 0x03A8;	 // Greek capital letter psi
-            case 0xD849: return 0x0399;	 // Greek capital letter iota
-            case 0xD84B: return 0x039A;	 // Greek capital letter kappa
-            case 0xD84C: return 0x039B;	 // Greek capital letter lamda
-            case 0xD84D: return 0x039C;	 // Greek capital letter mu
-            case 0xD84E: return 0x039D;	 // Greek capital letter nu
-            case 0xD84F: return 0x039F;	 // Greek capital letter omicron
-            case 0xD850: return 0x03A0;	 // Greek capital letter pi
-            case 0xD851: return 0x03A7;	 // Greek capital letter chi
-            case 0xD852: return 0x03A1;	 // Greek capital letter rho
-            case 0xD853: return 0x03A3;	 // Greek capital letter sigma
-            case 0xD854: return 0x03A4;	 // Greek capital letter tau
-            case 0xD855: return 0x03A9;	 // Greek capital letter omega
-            case 0xD856: return 0x0398;	 // Greek capital letter theta
-            case 0xD857: return 0x0397;	 // Greek capital letter eta
-            case 0xD858: return 0x039E;	 // Greek capital letter xi
-            case 0xD85A: return 0x0396;	 // Greek capital letter zeta
-            case 0xD861: return 0x03B1;	 // Greek small letter alpha
-            case 0xD862: return 0x03B2;	 // Greek small letter beta
-            case 0xD863: return 0x03C5;	 // Greek small letter upsilon
-            case 0xD864: return 0x03B4;	 // Greek small letter delta
-            case 0xD865: return 0x03B5;	 // Greek small letter epsilon
-            case 0xD866: return 0x03C6;	 // Greek small letter phi
-            case 0xD867: return 0x03B3;	 // Greek small letter gamma
-            case 0xD868: return 0x03C8;	 // Greek small letter psi
-            case 0xD869: return 0x03B9;	 // Greek small letter iota
-            case 0xD86B: return 0x03BA;	 // Greek small letter kappa
-            case 0xD86C: return 0x03BB;	 // Greek small letter lamda
-            case 0xD86D: return 0x03BC;	 // Greek small letter mu
-            case 0xD86E: return 0x03BD;	 // Greek small letter nu
-            case 0xD86F: return 0x03BF;	 // Greek small letter omicron
-            case 0xD870: return 0x03C0;	 // Greek small letter pi
-            case 0xD871: return 0x03C7;	 // Greek small letter chi
-            case 0xD872: return 0x03C1;	 // Greek small letter rho
-            case 0xD873: return 0x03C3;	 // Greek small letter sigma
-            case 0xD874: return 0x03C4;	 // Greek small letter tau
-            case 0xD875: return 0x03C9;	 // Greek small letter omega
-            case 0xD876: return 0x03B8;	 // Greek small letter theta
-            case 0xD877: return 0x03B7;	 // Greek small letter eta
-            case 0xD878: return 0x03BE;	 // Greek small letter xi
-            case 0xD87A: return 0x03B6;	 // Greek small letter zeta
-            case 0xD920: return 0x0E3F;	 // Thai currency symbol baht
-            case 0xD921: return 0x00A2;	 // cent sign
-            case 0xD922: return 0x00A5;	 // yen sign
-            case 0xD923: return 0x20A7;	 // peseta sign
-            case 0xD924: return 0x0192;	 // florin currency sign
-            case 0xD925: return 0x00A4;	 // currency sign
-            case 0xD926: return 0x20A4;	 // lira sign
-            case 0xD927: return 0x20A0;	 // Euro-currency sign
-            case 0xD928: return 0x20A1;	 // colon sign
-            case 0xD929: return 0x20A2;	 // cruzeiro sign
-            case 0xD92A: return 0x20A3;	 // French franc sign
-            case 0xD92B: return 0x20A5;	 // mill sign
-            case 0xD92C: return 0x20A6;	 // naira sign
-            case 0xD92D: return 0x20A8;	 // rupee sign
-            case 0xD92E: return 0x20A9;	 // won sign
-            case 0xD92F: return 0x20AA;	 // new sheqel sign
-            case 0xD930: return 0x20AC;	 // Euro sign
-            case 0xD931: return 0x00B9;	 // superscript one
-            case 0xD932: return 0x00B2;	 // superscript two
-            case 0xD933: return 0x00B3;	 // superscript three
-            case 0xD941: return 0x00AA;	 // feminine ordinal indicator
-            case 0xD942: return 0x00BA;	 // masculine ordinal indicator
-            case 0xD943: return 0x00AB;	 // left-pointing double angle quotation mark
-            case 0xD944: return 0x00BB;	 // right-pointing double angle quotation mark
-            case 0xD945: return 0x00A6;	 // broken vertical bar
-            case 0xD946: return 0x00B6;	 // pilcrow/paragraph sign
-            case 0xD947: return 0x00A7;	 // section sign
-            case 0xD948: return 0x2310;	 // reversed not sign
-            case 0xD949: return 0x2020;	 // dagger
-            case 0xD94A: return 0x2021;	 // double dagger
-            case 0xD94C: return 0x2122;	 // trade mark sign
-            case 0xD94D: return 0xFB01;	 // Latin small ligature fi
-            case 0xD94E: return 0xFB02;	 // Latin small ligature fl
-            case 0xD94F: return 0x2039;	 // left-pointing single angle quotation mark
-            case 0xD950: return 0x203A;	 // right-pointing single angle quotation mark
-            case 0xD951: return 0x2030;	 // per mille sign
-            case 0xD952: return 0x2026;	 // horizontal ellipsis
-            case 0xD953: return 0x201C;	 // left double quotation mark
-            case 0xD954: return 0x201D;	 // right double quotation mark
-            case 0xD955: return 0x201A;	 // single low-9 quotation mark
-            case 0xD956: return 0x201E;	 // double low-9 quotation mark
-            case 0xD957: return 0x2022;	 // bullet
-            case 0xD958: return 0x2013;	 // en dash
-            case 0xD959: return 0x00A0;	 // no-break space
-            case 0xD95A: return 0x00B5;	 // micro sign
-            case 0xD961: return 0x00BD;	 // vulgar fraction one half
-            case 0xD962: return 0x00BC;	 // vulgar fraction one quarter
-            case 0xD963: return 0x00BE;	 // vulgar fraction three quarters
-            case 0xD964: return 0x221E;	 // infinity
-            case 0xD965: return 0x2205;	 // empty set
-            case 0xD966: return 0x2208;	 // element of
-            case 0xD967: return 0x2229;	 // intersection
-            case 0xD968: return 0x00AC;	 // not sign
-            case 0xD969: return 0x2261;	 // identical to
-            case 0xD96A: return 0x00D7;	 // multiplication sign
-            case 0xD96B: return 0x2265;	 // greater-than or equal to
-            case 0xD96C: return 0x2264;	 // less-than or equal to
-            case 0xD96D: return 0x00F7;	 // division sign
-            case 0xD96E: return 0x2248;	 // almost equal to
-            case 0xD96F: return 0x22C5;	 // dot operator
-            case 0xD970: return 0x2320;	 // top half integral
-            case 0xD971: return 0x2321;	 // bottom half integral
-            case 0xD972: return 0x221A;	 // square root
-            case 0xD973: return 0x2044;	 // fraction/division slash
-            case 0xD974: return 0x2018;	 // left single quotation mark
-            case 0xD975: return 0x2019;	 // right single quotation mark
-            case 0xD976: return 0x2014;	 // em dash
-            case 0xD977: return 0x00AD;	 // soft hyphen
-            case 0xD979: return 0x20AD;	 // kip sign
-            case 0xD97A: return 0x20AE;	 // tugrik sign
-            case 0xD97B: return 0x20AF;	 // drachma sign
-            case 0xD97C: return 0x20AB;	 // dong sign
+            case 0xD741: return 0x2550;  //  box drawings double horizontal
+            case 0xD742: return 0x2551;  //  box drawings double vertical
+            case 0xD743: return 0x2557;  //  box drawings double down and left
+            case 0xD744: return 0x255D;  //  box drawings double up and left
+            case 0xD745: return 0x255A;  //  box drawings double up and right
+            case 0xD746: return 0x2554;  //  box drawings double down and right
+            case 0xD747: return 0x2563;  //  box drawings double vertical and left
+            case 0xD748: return 0x2569;  //  box drawings double up and horizontal
+            case 0xD749: return 0x2560;  //  box drawings double vertical and right
+            case 0xD74A: return 0x2566;  //  box drawings double down and horizontal
+            case 0xD74B: return 0x256C;  //  box drawings double vertical and horizontal
+            case 0xD74C: return 0x2562;  //  box drawings double vertical and single left
+            case 0xD74D: return 0x2567;  //  box drawings single up and double horizontal
+            case 0xD74E: return 0x255F;  //  box drawings double vertical and single right
+            case 0xD74F: return 0x2564;  //  box drawings single down and double horizontal
+            case 0xD750: return 0x2561;  //  box drawings single vertical and double left
+            case 0xD751: return 0x2568;  //  box drawings double up and single horizontal
+            case 0xD752: return 0x255E;  //  box drawings single vertical and double right
+            case 0xD753: return 0x2565;  //  box drawings double down and single horizontal
+            case 0xD754: return 0x256A;  //  box drawings single vertical and double horizontal
+            case 0xD755: return 0x2591;  //  light shade - 25%
+            case 0xD756: return 0x2592;  //  medium shade - 50%
+            case 0xD757: return 0x2593;  //  dark shade - 75%
+            case 0xD758: return 0x2588;  //  full block
+            case 0xD761: return 0x2500;  //  box drawings light horizontal
+            case 0xD762: return 0x2502;  //  box drawings light vertical
+            case 0xD763: return 0x2510;  //  box drawings light down and left
+            case 0xD764: return 0x2518;  //  box drawings light up and left
+            case 0xD765: return 0x2514;  //  box drawings light up and right
+            case 0xD766: return 0x250C;  //  box drawings light down and right
+            case 0xD767: return 0x2524;  //  box drawings light vertical and left
+            case 0xD768: return 0x2534;  //  box drawings light up and horizontal
+            case 0xD769: return 0x251C;  //  box drawings light vertical and right
+            case 0xD76A: return 0x252C;  //  box drawings light down and horizontal
+            case 0xD76B: return 0x253C;  //  box drawings light vertical and horizontal
+            case 0xD76C: return 0x2555;  //  box drawings light single down and double left
+            case 0xD76D: return 0x255B;  //  box drawings light single up and double left
+            case 0xD76E: return 0x2558;  //  box drawings light single up and double right
+            case 0xD76F: return 0x2552;  //  box drawings light single down and double right
+            case 0xD770: return 0x2556;  //  box drawings light double down and single left
+            case 0xD771: return 0x255C;  //  box drawings light double up and single left
+            case 0xD772: return 0x2559;  //  box drawings light double up and single right
+            case 0xD773: return 0x2553;  //  box drawings light double down and single right
+            case 0xD774: return 0x256B;  //  box drawings light double vertical and single horizontal
+            case 0xD775: return 0x258C;  //  left half block
+            case 0xD776: return 0x2580;  //  upper half block
+            case 0xD777: return 0x2590;  //  right half block
+            case 0xD778: return 0x2584;  //  lower half block
+            case 0xD779: return 0x25AA;  //  black small square
+            case 0xD824: return 0x03C2;  //  Greek small letter final sigma
+            case 0xD841: return 0x0391;  //  Greek capital letter alpha
+            case 0xD842: return 0x0392;  //  Greek capital letter beta
+            case 0xD843: return 0x03A5;  //  Greek capital letter upsilon
+            case 0xD844: return 0x0394;  //  Greek capital letter delta
+            case 0xD845: return 0x0395;  //  Greek capital letter epsilon
+            case 0xD846: return 0x03A6;  //  Greek capital letter phi
+            case 0xD847: return 0x0393;  //  Greek capital letter gamma
+            case 0xD848: return 0x03A8;  //  Greek capital letter psi
+            case 0xD849: return 0x0399;  //  Greek capital letter iota
+            case 0xD84B: return 0x039A;  //  Greek capital letter kappa
+            case 0xD84C: return 0x039B;  //  Greek capital letter lamda
+            case 0xD84D: return 0x039C;  //  Greek capital letter mu
+            case 0xD84E: return 0x039D;  //  Greek capital letter nu
+            case 0xD84F: return 0x039F;  //  Greek capital letter omicron
+            case 0xD850: return 0x03A0;  //  Greek capital letter pi
+            case 0xD851: return 0x03A7;  //  Greek capital letter chi
+            case 0xD852: return 0x03A1;  //  Greek capital letter rho
+            case 0xD853: return 0x03A3;  //  Greek capital letter sigma
+            case 0xD854: return 0x03A4;  //  Greek capital letter tau
+            case 0xD855: return 0x03A9;  //  Greek capital letter omega
+            case 0xD856: return 0x0398;  //  Greek capital letter theta
+            case 0xD857: return 0x0397;  //  Greek capital letter eta
+            case 0xD858: return 0x039E;  //  Greek capital letter xi
+            case 0xD85A: return 0x0396;  //  Greek capital letter zeta
+            case 0xD861: return 0x03B1;  //  Greek small letter alpha
+            case 0xD862: return 0x03B2;  //  Greek small letter beta
+            case 0xD863: return 0x03C5;  //  Greek small letter upsilon
+            case 0xD864: return 0x03B4;  //  Greek small letter delta
+            case 0xD865: return 0x03B5;  //  Greek small letter epsilon
+            case 0xD866: return 0x03C6;  //  Greek small letter phi
+            case 0xD867: return 0x03B3;  //  Greek small letter gamma
+            case 0xD868: return 0x03C8;  //  Greek small letter psi
+            case 0xD869: return 0x03B9;  //  Greek small letter iota
+            case 0xD86B: return 0x03BA;  //  Greek small letter kappa
+            case 0xD86C: return 0x03BB;  //  Greek small letter lamda
+            case 0xD86D: return 0x03BC;  //  Greek small letter mu
+            case 0xD86E: return 0x03BD;  //  Greek small letter nu
+            case 0xD86F: return 0x03BF;  //  Greek small letter omicron
+            case 0xD870: return 0x03C0;  //  Greek small letter pi
+            case 0xD871: return 0x03C7;  //  Greek small letter chi
+            case 0xD872: return 0x03C1;  //  Greek small letter rho
+            case 0xD873: return 0x03C3;  //  Greek small letter sigma
+            case 0xD874: return 0x03C4;  //  Greek small letter tau
+            case 0xD875: return 0x03C9;  //  Greek small letter omega
+            case 0xD876: return 0x03B8;  //  Greek small letter theta
+            case 0xD877: return 0x03B7;  //  Greek small letter eta
+            case 0xD878: return 0x03BE;  //  Greek small letter xi
+            case 0xD87A: return 0x03B6;  //  Greek small letter zeta
+            case 0xD920: return 0x0E3F;  //  Thai currency symbol baht
+            case 0xD921: return 0x00A2;  //  cent sign
+            case 0xD922: return 0x00A5;  //  yen sign
+            case 0xD923: return 0x20A7;  //  peseta sign
+            case 0xD924: return 0x0192;  //  florin currency sign
+            case 0xD925: return 0x00A4;  //  currency sign
+            case 0xD926: return 0x20A4;  //  lira sign
+            case 0xD927: return 0x20A0;  //  Euro-currency sign
+            case 0xD928: return 0x20A1;  //  colon sign
+            case 0xD929: return 0x20A2;  //  cruzeiro sign
+            case 0xD92A: return 0x20A3;  //  French franc sign
+            case 0xD92B: return 0x20A5;  //  mill sign
+            case 0xD92C: return 0x20A6;  //  naira sign
+            case 0xD92D: return 0x20A8;  //  rupee sign
+            case 0xD92E: return 0x20A9;  //  won sign
+            case 0xD92F: return 0x20AA;  //  new sheqel sign
+            case 0xD930: return 0x20AC;  //  Euro sign
+            case 0xD931: return 0x00B9;  //  superscript one
+            case 0xD932: return 0x00B2;  //  superscript two
+            case 0xD933: return 0x00B3;  //  superscript three
+            case 0xD941: return 0x00AA;  //  feminine ordinal indicator
+            case 0xD942: return 0x00BA;  //  masculine ordinal indicator
+            case 0xD943: return 0x00AB;  //  left-pointing double angle quotation mark
+            case 0xD944: return 0x00BB;  //  right-pointing double angle quotation mark
+            case 0xD945: return 0x00A6;  //  broken vertical bar
+            case 0xD946: return 0x00B6;  //  pilcrow/paragraph sign
+            case 0xD947: return 0x00A7;  //  section sign
+            case 0xD948: return 0x2310;  //  reversed not sign
+            case 0xD949: return 0x2020;  //  dagger
+            case 0xD94A: return 0x2021;  //  double dagger
+            case 0xD94C: return 0x2122;  //  trade mark sign
+            case 0xD94D: return 0xFB01;  //  Latin small ligature fi
+            case 0xD94E: return 0xFB02;  //  Latin small ligature fl
+            case 0xD94F: return 0x2039;  //  left-pointing single angle quotation mark
+            case 0xD950: return 0x203A;  //  right-pointing single angle quotation mark
+            case 0xD951: return 0x2030;  //  per mille sign
+            case 0xD952: return 0x2026;  //  horizontal ellipsis
+            case 0xD953: return 0x201C;  //  left double quotation mark
+            case 0xD954: return 0x201D;  //  right double quotation mark
+            case 0xD955: return 0x201A;  //  single low-9 quotation mark
+            case 0xD956: return 0x201E;  //  double low-9 quotation mark
+            case 0xD957: return 0x2022;  //  bullet
+            case 0xD958: return 0x2013;  //  en dash
+            case 0xD959: return 0x00A0;  //  no-break space
+            case 0xD95A: return 0x00B5;  //  micro sign
+            case 0xD961: return 0x00BD;  //  vulgar fraction one half
+            case 0xD962: return 0x00BC;  //  vulgar fraction one quarter
+            case 0xD963: return 0x00BE;  //  vulgar fraction three quarters
+            case 0xD964: return 0x221E;  //  infinity
+            case 0xD965: return 0x2205;  //  empty set
+            case 0xD966: return 0x2208;  //  element of
+            case 0xD967: return 0x2229;  //  intersection
+            case 0xD968: return 0x00AC;  //  not sign
+            case 0xD969: return 0x2261;  //  identical to
+            case 0xD96A: return 0x00D7;  //  multiplication sign
+            case 0xD96B: return 0x2265;  //  greater-than or equal to
+            case 0xD96C: return 0x2264;  //  less-than or equal to
+            case 0xD96D: return 0x00F7;  //  division sign
+            case 0xD96E: return 0x2248;  //  almost equal to
+            case 0xD96F: return 0x22C5;  //  dot operator
+            case 0xD970: return 0x2320;  //  top half integral
+            case 0xD971: return 0x2321;  //  bottom half integral
+            case 0xD972: return 0x221A;  //  square root
+            case 0xD973: return 0x2044;  //  fraction/division slash
+            case 0xD974: return 0x2018;  //  left single quotation mark
+            case 0xD975: return 0x2019;  //  right single quotation mark
+            case 0xD976: return 0x2014;  //  em dash
+            case 0xD977: return 0x00AD;  //  soft hyphen
+            case 0xD979: return 0x20AD;  //  kip sign
+            case 0xD97A: return 0x20AE;  //  tugrik sign
+            case 0xD97B: return 0x20AF;  //  drachma sign
+            case 0xD97C: return 0x20AB;  //  dong sign
 
             default: return -1;
         } //end switch

--- a/src/main/java/org/gedml/AnselOutputStreamWriter.java
+++ b/src/main/java/org/gedml/AnselOutputStreamWriter.java
@@ -86,6 +86,7 @@ public class AnselOutputStreamWriter extends OutputStreamWriter
 
         case 0x00A1: return 0xC6;  //  inverted exclamation mark
         case 0x00A3: return 0xB9;  //  pound sign
+        case 0x00A8: return 0xE820;  //  space with diaeresis
         case 0x00A9: return 0xC3;  //  copyright sign
         case 0x00AE: return 0xAA;  //  registered trade mark sign
         case 0x00B0: return 0xC0;  //  degree sign, ring above
@@ -297,8 +298,21 @@ public class AnselOutputStreamWriter extends OutputStreamWriter
         case 0x01FD: return 0xE2B5;  //  small ae with acute
         case 0x02B9: return 0xA7;  //  modified letter prime
         case 0x02BA: return 0xB7;  //  modified letter double prime
+        case 0x02BC: return 0xED20;  //  space with high comma
         case 0x02BE: return 0xAE;  //  modifier letter right half ring
         case 0x02BF: return 0xB0;  //  modifier letter left half ring
+        case 0x02C0: return 0xE020;  //  space with low-rising tone mark
+        case 0x02C6: return 0xE320;  //  space with circumflex accent
+        case 0x02C7: return 0xE920;  //  space with caron
+        case 0x02C9: return 0xE520;  //  space with macron
+        case 0x02CA: return 0xE220;  //  space with acute accent
+        case 0x02CB: return 0xE120;  //  space with grave accent
+        case 0x02D8: return 0xE620;  //  space with breve
+        case 0x02D9: return 0xE720;  //  space with dot above
+        case 0x02DA: return 0xEA20;  //  space with ring above
+        case 0x02DB: return 0xF120;  //  space with ogonek
+        case 0x02DC: return 0xE420;  //  space with tilde
+        case 0x02DD: return 0xEE20;  //  space with double acute accent
         case 0x0300: return 0xE1;  //  grave accent
         case 0x0301: return 0xE2;  //  acute accent
         case 0x0302: return 0xE3;  //  circumflex accent
@@ -442,6 +456,7 @@ public class AnselOutputStreamWriter extends OutputStreamWriter
         case 0x1EF9: return 0xE479;  //  small y with tilde
         case 0x200C: return 0x8E;    //  zero width non-joiner
         case 0x200D: return 0x8D;    //  zero width joiner
+        case 0x2017: return 0xF520;  //  space with double line below
         case 0x2113: return 0xC1;  //  script small l
         case 0x2117: return 0xC2;  //  sound recording copyright
         case 0x266D: return 0xA9;  //  music flat sign
@@ -460,6 +475,194 @@ public class AnselOutputStreamWriter extends OutputStreamWriter
         case 0x201D: return 0x94;    // right double quotation mark (not in the standard)
         case 0x20AC: return 0xC8;  //  euro sign
         case 0x0308: return 0xE8;  //  umlaut, diaeresis
+        // FamilySearch Extensions
+        case 0x0338: return 0xFC20;  // space with diagonal stroke
+        case 0x00A0: return 0xD959;  // no-break space
+        case 0x00A2: return 0xD921;  // cent sign
+        case 0x00A4: return 0xD925;  // currency sign
+        case 0x00A5: return 0xD922;  // yen sign
+        case 0x00A6: return 0xD945;  // broken vertical bar
+        case 0x00A7: return 0xD947;  // section sign
+        case 0x00AA: return 0xD941;  // feminine ordinal indicator
+        case 0x00AB: return 0xD943;  // left-pointing double angle quotation mark
+        case 0x00AC: return 0xD968;  // not sign
+        case 0x00AD: return 0xD977;  // soft hyphen
+        case 0x00B2: return 0xD932;  // superscript two
+        case 0x00B3: return 0xD933;  // superscript three
+        case 0x00B5: return 0xD95A;  // micro sign
+        case 0x00B6: return 0xD946;  // pilcrow/paragraph sign
+        case 0x00B9: return 0xD931;  // superscript one
+        case 0x00BA: return 0xD942;  // masculine ordinal indicator
+        case 0x00BB: return 0xD944;  // right-pointing double angle quotation mark
+        case 0x00BC: return 0xD962;  // vulgar fraction one quarter
+        case 0x00BD: return 0xD961;  // vulgar fraction one half
+        case 0x00BE: return 0xD963;  // vulgar fraction three quarters
+        case 0x00D7: return 0xD96A;  // multiplication sign
+        case 0x00F7: return 0xD96D;  // division sign
+        case 0x0192: return 0xD924;  // florin currency sign
+        case 0x023A: return 0xFC41;  // capital A with diagonal stroke
+        case 0x023B: return 0xFC43;  // capital C with diagonal stroke
+        case 0x023C: return 0xFC63;  // small c with diagonal stroke
+        case 0x023E: return 0xFC54;  // capital T with diagonal stroke
+        case 0x0246: return 0xFC45;  // capital E with diagonal stroke
+        case 0x0247: return 0xFC65;  // small e with diagonal stroke
+        case 0x0391: return 0xD841;  // Greek capital letter alpha
+        case 0x0392: return 0xD842;  // Greek capital letter beta
+        case 0x0393: return 0xD847;  // Greek capital letter gamma
+        case 0x0394: return 0xD844;  // Greek capital letter delta
+        case 0x0395: return 0xD845;  // Greek capital letter epsilon
+        case 0x0396: return 0xD85A;  // Greek capital letter zeta
+        case 0x0397: return 0xD857;  // Greek capital letter eta
+        case 0x0398: return 0xD856;  // Greek capital letter theta
+        case 0x0399: return 0xD849;  // Greek capital letter iota
+        case 0x039A: return 0xD84B;  // Greek capital letter kappa
+        case 0x039B: return 0xD84C;  // Greek capital letter lamda
+        case 0x039C: return 0xD84D;  // Greek capital letter mu
+        case 0x039D: return 0xD84E;  // Greek capital letter nu
+        case 0x039E: return 0xD858;  // Greek capital letter xi
+        case 0x039F: return 0xD84F;  // Greek capital letter omicron
+        case 0x03A0: return 0xD850;  // Greek capital letter pi
+        case 0x03A1: return 0xD852;  // Greek capital letter rho
+        case 0x03A3: return 0xD853;  // Greek capital letter sigma
+        case 0x03A4: return 0xD854;  // Greek capital letter tau
+        case 0x03A5: return 0xD843;  // Greek capital letter upsilon
+        case 0x03A6: return 0xD846;  // Greek capital letter phi
+        case 0x03A7: return 0xD851;  // Greek capital letter chi
+        case 0x03A8: return 0xD848;  // Greek capital letter psi
+        case 0x03A9: return 0xD855;  // Greek capital letter omega
+        case 0x03B1: return 0xD861;  // Greek small letter alpha
+        case 0x03B2: return 0xD862;  // Greek small letter beta
+        case 0x03B3: return 0xD867;  // Greek small letter gamma
+        case 0x03B4: return 0xD864;  // Greek small letter delta
+        case 0x03B5: return 0xD865;  // Greek small letter epsilon
+        case 0x03B6: return 0xD87A;  // Greek small letter zeta
+        case 0x03B7: return 0xD877;  // Greek small letter eta
+        case 0x03B8: return 0xD876;  // Greek small letter theta
+        case 0x03B9: return 0xD869;  // Greek small letter iota
+        case 0x03BA: return 0xD86B;  // Greek small letter kappa
+        case 0x03BB: return 0xD86C;  // Greek small letter lamda
+        case 0x03BC: return 0xD86D;  // Greek small letter mu
+        case 0x03BD: return 0xD86E;  // Greek small letter nu
+        case 0x03BE: return 0xD878;  // Greek small letter xi
+        case 0x03BF: return 0xD86F;  // Greek small letter omicron
+        case 0x03C0: return 0xD870;  // Greek small letter pi
+        case 0x03C1: return 0xD872;  // Greek small letter rho
+        case 0x03C2: return 0xD824;  // Greek small letter final sigma
+        case 0x03C3: return 0xD873;  // Greek small letter sigma
+        case 0x03C4: return 0xD874;  // Greek small letter tau
+        case 0x03C5: return 0xD863;  // Greek small letter upsilon
+        case 0x03C6: return 0xD866;  // Greek small letter phi
+        case 0x03C7: return 0xD871;  // Greek small letter chi
+        case 0x03C8: return 0xD868;  // Greek small letter psi
+        case 0x03C9: return 0xD875;  // Greek small letter omega
+        case 0x0E3F: return 0xD920;  // Thai currency symbol baht
+        case 0x2013: return 0xD958;  // en dash
+        case 0x2014: return 0xD976;  // em dash
+        case 0x2018: return 0xD974;  // left single quotation mark
+        case 0x2019: return 0xD975;  // right single quotation mark
+        case 0x201A: return 0xD955;  // single low-9 quotation mark
+        //case 0x201C: return 0xD953;  // left double quotation mark (conflicts with WeRelate)
+        //case 0x201D: return 0xD954;  // right double quotation mark (conflicts with WeRelate)
+        case 0x201E: return 0xD956;  // double low-9 quotation mark
+        case 0x2020: return 0xD949;  // dagger
+        case 0x2021: return 0xD94A;  // double dagger
+        case 0x2022: return 0xD957;  // bullet
+        case 0x2026: return 0xD952;  // horizontal ellipsis
+        case 0x2030: return 0xD951;  // per mille sign
+        case 0x2039: return 0xD94F;  // left-pointing single angle quotation mark
+        case 0x203A: return 0xD950;  // right-pointing single angle quotation mark
+        case 0x2044: return 0xD973;  // fraction/division slash
+        case 0x20A0: return 0xD927;  // Euro-currency sign
+        case 0x20A1: return 0xD928;  // colon sign
+        case 0x20A2: return 0xD929;  // cruzeiro sign
+        case 0x20A3: return 0xD92A;  // French franc sign
+        case 0x20A4: return 0xD926;  // lira sign
+        case 0x20A5: return 0xD92B;  // mill sign
+        case 0x20A6: return 0xD92C;  // naira sign
+        case 0x20A7: return 0xD923;  // peseta sign
+        case 0x20A8: return 0xD92D;  // rupee sign
+        case 0x20A9: return 0xD92E;  // won sign
+        case 0x20AA: return 0xD92F;  // new sheqel sign
+        case 0x20AB: return 0xD97C;  // dong sign
+        //case 0x20AC: return 0xD930;  // Euro sign (conflicts with WeRelate)
+        case 0x20AD: return 0xD979;  // kip sign
+        case 0x20AE: return 0xD97A;  // tugrik sign
+        case 0x20AF: return 0xD97B;  // drachma sign
+        case 0x2122: return 0xD94C;  // trade mark sign
+        case 0x2205: return 0xD965;  // empty set
+        case 0x2208: return 0xD966;  // element of
+        case 0x221A: return 0xD972;  // square root
+        case 0x221E: return 0xD964;  // infinity
+        case 0x2229: return 0xD967;  // intersection
+        case 0x2248: return 0xD96E;  // almost equal to
+        case 0x2261: return 0xD969;  // identical to
+        case 0x2264: return 0xD96C;  // less-than or equal to
+        case 0x2265: return 0xD96B;  // greater-than or equal to
+        case 0x22C5: return 0xD96F;  // dot operator
+        case 0x2310: return 0xD948;  // reversed not sign
+        case 0x2320: return 0xD970;  // top half integral
+        case 0x2321: return 0xD971;  // bottom half integral
+        case 0x2500: return 0xD761;  // box drawings light horizontal
+        case 0x2502: return 0xD762;  // box drawings light vertical
+        case 0x250C: return 0xD766;  // box drawings light down and right
+        case 0x2510: return 0xD763;  // box drawings light down and left
+        case 0x2514: return 0xD765;  // box drawings light up and right
+        case 0x2518: return 0xD764;  // box drawings light up and left
+        case 0x251C: return 0xD769;  // box drawings light vertical and right
+        case 0x2524: return 0xD767;  // box drawings light vertical and left
+        case 0x252C: return 0xD76A;  // box drawings light down and horizontal
+        case 0x2534: return 0xD768;  // box drawings light up and horizontal
+        case 0x253C: return 0xD76B;  // box drawings light vertical and horizontal
+        case 0x2550: return 0xD741;  // box drawings double horizontal
+        case 0x2551: return 0xD742;  // box drawings double vertical
+        case 0x2552: return 0xD76F;  // box drawings light single down and double right
+        case 0x2553: return 0xD773;  // box drawings light double down and single right
+        case 0x2554: return 0xD746;  // box drawings double down and right
+        case 0x2555: return 0xD76C;  // box drawings light single down and double left
+        case 0x2556: return 0xD770;  // box drawings light double down and single left
+        case 0x2557: return 0xD743;  // box drawings double down and left
+        case 0x2558: return 0xD76E;  // box drawings light single up and double right
+        case 0x2559: return 0xD772;  // box drawings light double up and single right
+        case 0x255A: return 0xD745;  // box drawings double up and right
+        case 0x255B: return 0xD76D;  // box drawings light single up and double left
+        case 0x255C: return 0xD771;  // box drawings light double up and single left
+        case 0x255D: return 0xD744;  // box drawings double up and left
+        case 0x255E: return 0xD752;  // box drawings single vertical and double right
+        case 0x255F: return 0xD74E;  // box drawings double vertical and single right
+        case 0x2560: return 0xD749;  // box drawings double vertical and right
+        case 0x2561: return 0xD750;  // box drawings single vertical and double left
+        case 0x2562: return 0xD74C;  // box drawings double vertical and single left
+        case 0x2563: return 0xD747;  // box drawings double vertical and left
+        case 0x2564: return 0xD74F;  // box drawings single down and double horizontal
+        case 0x2565: return 0xD753;  // box drawings double down and single horizontal
+        case 0x2566: return 0xD74A;  // box drawings double down and horizontal
+        case 0x2567: return 0xD74D;  // box drawings single up and double horizontal
+        case 0x2568: return 0xD751;  // box drawings double up and single horizontal
+        case 0x2569: return 0xD748;  // box drawings double up and horizontal
+        case 0x256A: return 0xD754;  // box drawings single vertical and double horizontal
+        case 0x256B: return 0xD774;  // box drawings light double vertical and single horizontal
+        case 0x256C: return 0xD74B;  // box drawings double vertical and horizontal
+        case 0x2580: return 0xD776;  // upper half block
+        case 0x2584: return 0xD778;  // lower half block
+        case 0x2588: return 0xD758;  // full block
+        case 0x258C: return 0xD775;  // left half block
+        case 0x2590: return 0xD777;  // right half block
+        case 0x2591: return 0xD755;  // light shade - 25%
+        case 0x2592: return 0xD756;  // medium shade - 50%
+        case 0x2593: return 0xD757;  // dark shade - 75%
+        case 0x25AA: return 0xD779;  // black small square
+        case 0x25AE: return 0xBF;    // black vertical rectangle
+        case 0x25AF: return 0xBE;    // white vertical rectangle
+        case 0x2C65: return 0xFC61;  // small a with diagonal stroke
+        case 0x2C66: return 0xFC74;  // small t with diagonal stroke
+        case 0xA742: return 0xFC4B;  // capital K with diagonal stroke
+        case 0xA743: return 0xFC6B;  // small k with diagonal stroke
+        case 0xA758: return 0xFC51;  // capital Q with diagonal stroke
+        case 0xA759: return 0xFC71;  // small q with diagonal stroke
+        case 0xA75E: return 0xFC56;  // capital V with diagonal stroke
+        case 0xA75F: return 0xFC76;  // small v with diagonal stroke
+        case 0xFB01: return 0xD94D;  // Latin small ligature fi
+        case 0xFB02: return 0xD94E;  // Latin small ligature fl
 
         default: return 0xC5;     // if no match, use inverted '?'
       } //end switch


### PR DESCRIPTION
After ANSEL was included in the GEDCOM standard, some extensions were added by FamilySearch (see https://en.wikipedia.org/wiki/ANSEL for these extensions).

During work on the DOS version of PAF, some other extensions were added to facilitate sending extended characters not included in the ANSEL character set, but which were defined in the ASCII, Windows, and MAC character sets. These new extensions were defined with two-byte representations similar to the ANSEL 0xEn and 0xFn columns. The values 0xD7-0xD9 were defined as the first byte.

Code to create/read ANSEL files with these extensions was included in PAF versions from 2.x on (I don't remember the exact version), and code to read ANSEL files with these extensions was added to FamilySearch Family Tree. I have added these extensions to this code so that others can make use of the extensions.