### PR TITLE
Change log level to trace to due to data being logged should not be i…

### DIFF
--- a/src/main/java/org/folg/gedcom/parser/ModelParser.java
+++ b/src/main/java/org/folg/gedcom/parser/ModelParser.java
@@ -1535,7 +1535,7 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
          errorHandler.warning(exception.getMessage(), exception.getLineNumber());
       }
       else {
-         logger.info(exception.getMessage() + " @ " + exception.getLineNumber());
+         logger.trace(exception.getMessage() + " @ " + exception.getLineNumber());
       }
    }
 


### PR DESCRIPTION
As mentioned in this [Issue](https://github.com/FamilySearch/gedcom5-java/issues/23), while parsing a Legacy Generated family tree file, it attached some Gedcom Tags that while parsing at an info level proved to be noisy and hurt performance. This change is to move the level down to Trace.

Here is an example of the Gedcom Tags Legacy adds
```
0 @I1@ INDI
1 NAME George /Washington/
2 GIVN George
2 SURN Washington
1 SEX M
1 _TAG2
```