### PR TITLE
Build a fat jar to allow easy execution outside of maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ stored as extensions and errors.
 the model using a Visitor pattern. This function was written in just a few lines due to the other
 classes in this project.
 
-The tools can be run using
-`mvn exec:java -Dexec.mainClass=org.folg.gedcom.tools.<tool name> -Dexec.args="<args>"`
+The tools can be run using the `gedcom.jar` archive from the `target` directory:
+`java -cp target/gedcom.jar org.folg.gedcom.tools.<tool name> <args>`
+
+For example: `java -cp target/gedcom.jar org.folg.gedcom.tools.Gedcom2Json -i mytree.ged -o mytree.json`
 
 Roadmap
 -------

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,28 @@
           <target>1.8</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>with-deps</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <attach>false</attach>
+              <finalName>${project.artifactId}</finalName>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
I added maven configuration to build a jar with dependencies.  This allows people to run the tools easily outside of the maven environment, which greatly simplifies passing arguments.  It also allows the tool to be more easily run from another directory.

I used <attach> set to false which prevents the jar from being part of maven release.  Mostly because I feel it's more user-friendly to leave the version off of the fat jar and that makes it unsuitable for the maven release.