### PR TITLE
Support EventFact age

### DIFF
--- a/src/main/java/org/folg/gedcom/model/EventFact.java
+++ b/src/main/java/org/folg/gedcom/model/EventFact.java
@@ -22,7 +22,7 @@ import java.util.*;
  * User: Dallan
  * Date: 12/25/11
  * 
- * omit: Phone, Age, Agency, Cause (except for death events)
+ * omit: Phone, Agency, Cause (except for death events)
  * add: Rin, Uid
  */
 public class EventFact extends SourceCitationContainer {
@@ -192,6 +192,9 @@ public class EventFact extends SourceCitationContainer {
    private String date = null;
    private String place = null;
    private Address addr = null;
+   private String age = null;
+   private Spouse husb = null;
+   private Spouse wife = null;
    private String phon = null;
    private String fax = null;
    private String rin = null;
@@ -264,6 +267,30 @@ public class EventFact extends SourceCitationContainer {
 
    public void setAddress(Address addr) {
       this.addr = addr;
+   }
+
+   public String getAge() {
+      return age;
+   }
+
+   public void setAge(String age) {
+      this.age = age;
+   }
+
+   public Spouse getHusband() {
+      return husb;
+   }
+
+   public void setHusband(Spouse husb) {
+      this.husb = husb;
+   }
+
+   public Spouse getWife() {
+      return wife;
+   }
+
+   public void setWife(Spouse wife) {
+      this.wife = wife;
    }
 
    public String getPhone() {
@@ -350,6 +377,12 @@ public class EventFact extends SourceCitationContainer {
    public void visitContainedObjects(Visitor visitor) {
       if (addr != null) {
          addr.accept(visitor);
+      }
+      if (husb != null) {
+         husb.accept(visitor, true);
+      }
+      if (wife != null) {
+         wife.accept(visitor, false);
       }
       super.visitContainedObjects(visitor);
    }

--- a/src/main/java/org/folg/gedcom/model/Spouse.java
+++ b/src/main/java/org/folg/gedcom/model/Spouse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2011 Foundation for On-Line Genealogy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.folg.gedcom.model;
+
+public class Spouse extends ExtensionContainer {
+   private String age = null;
+
+   public String getAge() {
+      return age;
+   }
+
+   public void setAge(String age) {
+      this.age = age;
+   }
+
+   public void accept(Visitor visitor) {
+      throw new RuntimeException("Not implemented - pass isHusband");
+   }
+
+   public void accept(Visitor visitor, boolean isHusband) {
+      if (visitor.visit(this, isHusband)) {
+         super.visitContainedObjects(visitor);
+         visitor.endVisit(this);
+      }
+   }
+}

--- a/src/main/java/org/folg/gedcom/model/Visitor.java
+++ b/src/main/java/org/folg/gedcom/model/Visitor.java
@@ -51,6 +51,7 @@ public class Visitor {
    public boolean visit(RepositoryRef repositoryRef) {return true;}
    public boolean visit(Source source) {return true;}
    public boolean visit(SourceCitation sourceCitation) {return true;}
+   public boolean visit(Spouse spouse, boolean isHusband) {return true;}
    public boolean visit(SpouseRef spouseRef, boolean isHusband) {return true;}
    public boolean visit(SpouseFamilyRef spouseFamilyRef) {return true;}
    public boolean visit(Submission submission) {return true;}

--- a/src/main/java/org/folg/gedcom/parser/ModelParser.java
+++ b/src/main/java/org/folg/gedcom/parser/ModelParser.java
@@ -82,7 +82,7 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
    }
    
    public static enum Tag {
-      ABBR, ADDR, ADR1, ADR2, ADR3, _AKA, ALIA, ANCI, ASSO, AUTH,
+      ABBR, ADDR, ADR1, ADR2, ADR3, AGE, _AKA, ALIA, ANCI, ASSO, AUTH,
       BLOB,
       CALN, CAUS, CHAN, CHAR, CHIL, CITY, CONC, CONT, COPR, CORP, CTRY,
       DATA, DATE, DESC, DESI, DEST,
@@ -134,6 +134,9 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
                break;
             case ADR3:
                obj = handleAdr3(tos);
+               break;
+            case AGE:
+               obj = handleAge(tos);
                break;
            case _AKA:
                obj = handleAka(tos, tagName);
@@ -506,6 +509,14 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
    private Object handleAdr3(Object tos) {
       if (tos instanceof Address && ((Address)tos).getAddressLine3() == null) {
          return new FieldRef(tos, "AddressLine3");
+      }
+      return null;
+   }
+
+   private Object handleAge(Object tos) {
+      if (tos instanceof EventFact && ((EventFact)tos).getAge() == null ||
+          tos instanceof Spouse && ((Spouse)tos).getAge() == null) {
+         return new FieldRef(tos, "Age");
       }
       return null;
    }
@@ -915,6 +926,11 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
          spouseRef.setRef(ref);
          ((Family)tos).addHusband(spouseRef);
          return spouseRef;
+      }
+      else if (tos instanceof EventFact) {
+         Spouse spouse = new Spouse();
+         ((EventFact)tos).setHusband(spouse);
+         return spouse;
       }
       return null;
    }
@@ -1445,6 +1461,11 @@ public class ModelParser implements ContentHandler, org.xml.sax.ErrorHandler {
          spouseRef.setRef(ref);
          ((Family)tos).addWife(spouseRef);
          return spouseRef;
+      }
+      else if (tos instanceof EventFact) {
+         Spouse spouse = new Spouse();
+         ((EventFact)tos).setWife(spouse);
+         return spouse;
       }
       return null;
    }

--- a/src/main/java/org/folg/gedcom/visitors/GedcomWriter.java
+++ b/src/main/java/org/folg/gedcom/visitors/GedcomWriter.java
@@ -226,6 +226,7 @@ public class GedcomWriter extends Visitor {
       writeString("DATE", eventFact, eventFact.getDate());
       writeString("PLAC", eventFact, eventFact.getPlace());
       writeString("CAUS", eventFact, eventFact.getCause());
+      writeString("AGE", eventFact, eventFact.getAge());
       writeString("RIN", eventFact, eventFact.getRin());
       writeString(eventFact.getUidTag(), eventFact, eventFact.getUid());
    }
@@ -549,6 +550,14 @@ public class GedcomWriter extends Visitor {
          writeString("DATE", sourceCitation, sourceCitation.getDate());
          writeString("TEXT", sourceCitation, sourceCitation.getText());
       }
+      return true;
+   }
+
+   @Override
+   public boolean visit(Spouse spouse, boolean isHusband) {
+      write(isHusband ? "HUSB" : "WIFE");
+      stack.push(spouse);
+      writeString("AGE", spouse, spouse.getAge());
       return true;
    }
 


### PR DESCRIPTION
**Age at event** is an important part of the event detail in [GEDCOM standard 5.5.1](https://gedcom.io/specifications/ged551.pdf), both for individual:
```
INDIVIDUAL_EVENT_DETAIL:=
   n <<EVENT_DETAIL>>        {1:1}
   n AGE <AGE_AT_EVENT>      {0:1}
```
and for family:
```
FAMILY_EVENT_DETAIL:=
   n HUSB                    {0:1}
     +1 AGE <AGE_AT_EVENT>   {1:1}
   n WIFE                    {0:1}
     +1 AGE <AGE_AT_EVENT>   {1:1}
   n <<EVENT_DETAIL>>        {0:1} 
```
Unfortunately AGE tag is not explicitly supported by the gedcom5-java library.

This pull request adds all necessary APIs to `EventFact`.
Implementation is as simple as possible, anyway with complete round-trippable parsing and exporting.